### PR TITLE
Issue #70: In cases where the Identify is verified then issue new cert even if one not expired or revoked

### DIFF
--- a/certs/certfactory.h
+++ b/certs/certfactory.h
@@ -61,6 +61,7 @@ class PVXS_API CertFactory {
     std::string cert_config_uri_base_;
     std::string skid_;
     certstatus_t initial_status_;
+    bool allow_duplicates{true};
 
     /**
      * @brief Constructor for CertFactory

--- a/certs/pvacms.h
+++ b/certs/pvacms.h
@@ -221,7 +221,7 @@ class StatusMonitor {
 
 void checkForDuplicates(const sql_ptr &certs_db, const CertFactory &cert_factory);
 
-CertData createCaCertificate(const ConfigCms &config, sql_ptr &certs_db, const std::shared_ptr<KeyPair> &key_pair);
+CertData createCertAuthCertificate(const ConfigCms &config, sql_ptr &certs_db, const std::shared_ptr<KeyPair> &key_pair);
 
 ossl_ptr<X509> createCertificate(sql_ptr &certs_db, CertFactory &cert_factory);
 
@@ -251,7 +251,7 @@ time_t getNotAfterTimeFromCert(const X509 *cert);
 
 time_t getNotBeforeTimeFromCert(const X509 *cert);
 
-void getOrCreateCaCertificate(const ConfigCms &config, sql_ptr &certs_db, ossl_ptr<X509> &cert_auth_cert, ossl_ptr<EVP_PKEY> &cert_auth_pkey,
+void getOrCreateCertAuthCertificate(const ConfigCms &config, sql_ptr &certs_db, ossl_ptr<X509> &cert_auth_cert, ossl_ptr<EVP_PKEY> &cert_auth_pkey,
                               ossl_shared_ptr<STACK_OF(X509)> &cert_auth_chain, bool &is_initialising);
 
 void createDefaultAdminACF(const ConfigCms &config, const ossl_ptr<X509> &cert_auth_cert);


### PR DESCRIPTION
### Description

This pull request adds a new `allow_duplicates` flag to the `CertFactory`, allowing the issuance of a new certificate even if the existing one is neither expired nor revoked, as per Issue #70. 

Additionally:
- Renamed `CaCertificate` to `CertAuthCertificate` for improved clarity.
- Simplified string comparison for authentication type checks.
- Enforced duplicate checks within the certificate generation logic. 

These changes ensure better configurability and cleaner code in the certificate management process.

### Checklist

- [ ] Tests added/updated for new functionality  
- [ ] Documentation updated as required  
- [ ] Related issues linked