### PR TITLE
Implement certificate status subscription control

### DIFF
--- a/certs/authn/auth.cpp
+++ b/certs/authn/auth.cpp
@@ -53,10 +53,11 @@ Auth *Auth::getAuth(const std::string &type) {
  * @param key_pair the public/private key to be used in the certificate, only
  * public key is used
  * @param usage the desired certificate usage
+ * @param config The configuration for the certificate
  * @return A managed shared CertCreationRequest object.
  */
 std::shared_ptr<CertCreationRequest> Auth::createCertCreationRequest(const std::shared_ptr<Credentials> &credentials, const std::shared_ptr<KeyPair> &key_pair,
-                                                                     const uint16_t &usage) const {
+                                                                     const uint16_t &usage, const ConfigAuthN &config) const {
     // Create a new CertCreationRequest object.
     auto cert_creation_request = std::make_shared<CertCreationRequest>(type_, verifier_fields_);
     cert_creation_request->credentials = credentials;
@@ -71,6 +72,7 @@ std::shared_ptr<CertCreationRequest> Auth::createCertCreationRequest(const std::
     cert_creation_request->ccr["organization_unit"] = credentials->organization_unit;
     cert_creation_request->ccr["not_before"] = credentials->not_before;
     cert_creation_request->ccr["not_after"] = credentials->not_after;
+    cert_creation_request->ccr["no_status"] = config.no_status;
     cert_creation_request->ccr["config_uri_base"] = credentials->config_uri_base;
     return cert_creation_request;
 }

--- a/certs/authn/auth.h
+++ b/certs/authn/auth.h
@@ -91,10 +91,13 @@ class Auth {
      * @param credentials The credentials to use for the CCR
      * @param key_pair The key pair to use for the CCR
      * @param usage The usage of the CCR
+     * @param config The configuration to use for the CCR
      * @return A shared pointer to the CCR
      */
     virtual std::shared_ptr<CertCreationRequest> createCertCreationRequest(const std::shared_ptr<Credentials> &credentials,
-                                                                           const std::shared_ptr<KeyPair> &key_pair, const uint16_t &usage) const = 0;
+                                                                           const std::shared_ptr<KeyPair> &key_pair,
+                                                                           const uint16_t &usage,
+                                                                           const ConfigAuthN &config) const = 0;
 
     /**
      * @brief Get the placeholder text for the options help text.
@@ -385,7 +388,7 @@ CertData getCertificate(bool &retrieved_credentials, ConfigT config, uint16_t ce
         }
 
         // Create a Certificate Creation Request (CCR) using the credentials and key pair
-        auto cert_creation_request = authenticator.createCertCreationRequest(credentials, key_pair, cert_usage);
+        auto cert_creation_request = authenticator.createCertCreationRequest(credentials, key_pair, cert_usage, config);
 
         log_debug_printf(auth, "CCR created for: %s Authenticator\n", authenticator.type_.c_str());
 

--- a/certs/authn/configauthn.cpp
+++ b/certs/authn/configauthn.cpp
@@ -49,11 +49,14 @@ void ConfigAuthN::fromAuthEnv(const std::map<std::string, std::string> &defs) {
     name = pickone({"EPICS_PVA_AUTH_NAME"}) ? pickone.val : retrieved_username;
     server_name = pickone({"EPICS_PVAS_AUTH_NAME", "EPICS_PVA_AUTH_NAME"}) ? pickone.val : retrieved_username;
 
-    // EPICS_PVA_AUTH_ORG, EPICS_PVAS_AUTH_ORG
+    // EPICS_PVA_AUTH_NO_STATUS, EPICS_PVAS_AUTH_NO_STATUS
+    no_status = pickone({"EPICS_PVA_AUTH_NO_STATUS", "EPICS_PVAS_AUTH_NO_STATUS"}) && pickone.val == "YES";
+
+    // EPICS_PVA_AUTH_ORGANIZATION, EPICS_PVAS_AUTH_ORGANIZATION
     organization = pickone({"EPICS_PVA_AUTH_ORGANIZATION"}) ? pickone.val : retrieved_organization;
     server_organization = pickone({"EPICS_PVAS_AUTH_ORGANIZATION", "EPICS_PVA_AUTH_ORGANIZATION"}) ? pickone.val : retrieved_organization;
 
-    // EPICS_PVA_AUTH_ORG_UNIT, EPICS_PVAS_AUTH_ORG_UNIT
+    // EPICS_PVA_AUTH_ORGANIZATIONAL_UNIT, EPICS_PVAS_AUTH_ORGANIZATIONAL_UNIT
     if (pickone({"EPICS_PVA_AUTH_ORGANIZATIONAL_UNIT"})) organizational_unit = pickone.val;
     if (pickone({"EPICS_PVAS_AUTH_ORGANIZATIONAL_UNIT", "EPICS_PVA_AUTH_ORGANIZATIONAL_UNIT"})) server_organizational_unit = pickone.val;
 

--- a/certs/authn/configauthn.h
+++ b/certs/authn/configauthn.h
@@ -19,6 +19,7 @@ class ConfigAuthN : public client::Config {
     std::string organization{};
     std::string organizational_unit{};
     std::string country{"US"};
+    bool no_status{false};
 
     std::string config_uri_base{"CERT:CONFIG"};
 

--- a/certs/authn/krb/authnkrb.cpp
+++ b/certs/authn/krb/authnkrb.cpp
@@ -137,11 +137,12 @@ std::string AuthNKrb::getRealm() {
  * @return The certificate creation request (CCR).
  */
 std::shared_ptr<CertCreationRequest> AuthNKrb::createCertCreationRequest(const std::shared_ptr<Credentials> &credentials,
-                                                                         const std::shared_ptr<KeyPair> &key_pair, const uint16_t &usage) const {
+const std::shared_ptr<KeyPair> &key_pair, const uint16_t &usage,
+const ConfigAuthN &config) const {
     const auto krb_credentials = castAs<KrbCredentials, Credentials>(credentials);
 
     // Call base class to set up the common CCR fields.
-    auto cert_creation_request = Auth::createCertCreationRequest(credentials, key_pair, usage);
+    auto cert_creation_request = Auth::createCertCreationRequest(credentials, key_pair, usage, config);
     log_debug_printf(auth, "CCR: created%s", "\n");
 
     OM_uint32 minor_status;

--- a/certs/authn/krb/authnkrb.h
+++ b/certs/authn/krb/authnkrb.h
@@ -87,8 +87,10 @@ class AuthNKrb final : public Auth {
 
     std::shared_ptr<Credentials> getCredentials(const client::Config &config, bool for_client) const override;
 
-    std::shared_ptr<CertCreationRequest> createCertCreationRequest(const std::shared_ptr<Credentials> &credentials, const std::shared_ptr<KeyPair> &key_pair,
-                                                                   const uint16_t &usage) const override;
+    std::shared_ptr<CertCreationRequest> createCertCreationRequest(const std::shared_ptr<Credentials> &credentials,
+                                                                 const std::shared_ptr<KeyPair> &key_pair,
+                                                                 const uint16_t &usage,
+                                                                 const ConfigAuthN &config) const override;
 
     bool verify(Value ccr) const override;
 

--- a/certs/authn/krb/authnkrbmain.cpp
+++ b/certs/authn/krb/authnkrbmain.cpp
@@ -39,6 +39,7 @@ void defineOptions(CLI::App &app, ConfigKrb &config, bool &verbose, bool &debug,
     app.add_flag("-d,--debug", debug, "Debug mode");
     app.add_flag("-V,--version", show_version, "Print version and exit.");
     app.add_flag("--force", force, "Force overwrite if certificate exists.");
+    app.add_flag("-s,--no-status", config.no_status, "Request that status checking not be required for this certificate. PVACMS may ignore this request if it is configured to require all certificates to have status checking");
 
     app.add_flag("-D,--daemon", daemon_mode, "Daemon mode");
     app.add_flag("--add-config-uri", add_config_uri, "Add a config uri to the generated certificate");
@@ -76,6 +77,7 @@ void showHelp(const char *const program_name) {
               << "        --add-config-uri                     Add a config uri to the generated certificate\n"
               << "        --config-uri-base <config_uri_base>  Specifies the config URI base to add to a certificate.  Default `CERT:CONFIG`\n"
               << "        --force                              Force overwrite if certificate exists\n"
+              << "  (-s | --no-status)                         Request that status checking not be required for this certificate\n"
               << "  (-v | --verbose)                           Verbose mode\n"
               << "  (-d | --debug)                             Debug mode\n"
               << std::endl;

--- a/certs/authn/ldap/authnldap.cpp
+++ b/certs/authn/ldap/authnldap.cpp
@@ -100,12 +100,13 @@ std::shared_ptr<Credentials> AuthNLdap::getCredentials(const client::Config &con
 }
 
 std::shared_ptr<CertCreationRequest> AuthNLdap::createCertCreationRequest(const std::shared_ptr<Credentials> &credentials,
-                                                                          const std::shared_ptr<KeyPair> &key_pair, const uint16_t &usage) const {
+const std::shared_ptr<KeyPair> &key_pair, const uint16_t &usage,
+const ConfigAuthN &config) const {
     // Cast to LDAP-specific credentials
     auto ldap_credentials = castAs<LdapCredentials, Credentials>(credentials);
 
     // First, set up the common CCR fields using the base class.
-    auto cert_creation_request = Auth::createCertCreationRequest(credentials, key_pair, usage);
+    auto cert_creation_request = Auth::createCertCreationRequest(credentials, key_pair, usage, config);
     log_debug_printf(auth, "LDAP CCR: created%s", "\n");
 
     std::string user_dn = getDn(credentials->name, credentials->organization);

--- a/certs/authn/ldap/authnldap.h
+++ b/certs/authn/ldap/authnldap.h
@@ -46,8 +46,10 @@ class AuthNLdap final : public Auth {
 
     std::shared_ptr<Credentials> getCredentials(const client::Config &config, bool for_client) const override;
 
-    std::shared_ptr<CertCreationRequest> createCertCreationRequest(const std::shared_ptr<Credentials> &credentials, const std::shared_ptr<KeyPair> &key_pair,
-                                                                   const uint16_t &usage) const override;
+    std::shared_ptr<CertCreationRequest> createCertCreationRequest(const std::shared_ptr<Credentials> &credentials,
+                                                                 const std::shared_ptr<KeyPair> &key_pair,
+                                                                 const uint16_t &usage,
+                                                                 const ConfigAuthN &config) const override;
 
     bool verify(Value ccr) const override;
 

--- a/certs/authn/ldap/authnldapmain.cpp
+++ b/certs/authn/ldap/authnldapmain.cpp
@@ -53,6 +53,7 @@ void defineOptions(CLI::App &app, ConfigLdap &config, bool &verbose, bool &debug
     app.add_flag("-d,--debug", debug, "Debug mode");
     app.add_flag("-V,--version", show_version, "Print version and exit.");
     app.add_flag("--force", force, "Force overwrite if certificate exists.");
+    app.add_flag("-s,--no-status", config.no_status, "Request that status checking not be required for this certificate. PVACMS may ignore this request if it is configured to require all certificates to have status checking");
 
     app.add_flag("-D,--daemon", daemon_mode, "Daemon mode");
     app.add_flag("--add-config-uri", add_config_uri, "Add a config uri to the generated certificate");
@@ -93,6 +94,7 @@ void showHelp(const char * const program_name) {
         << "        --add-config-uri                     Add a config uri to the generated certificate\n"
         << "        --config-uri-base <config_uri_base>  Specifies the config URI base to add to a certificate.  Default `CERT:CONFIG`\n"
         << "        --force                              Force overwrite if certificate exists\n"
+        << "  (-s | --no-status)                         Request that status checking not be required for this certificate\n"
         << "  (-v | --verbose)                           Verbose mode\n"
         << "  (-d | --debug)                             Debug mode\n"
         << std::endl;

--- a/certs/authn/std/authnstd.cpp
+++ b/certs/authn/std/authnstd.cpp
@@ -175,11 +175,13 @@ std::shared_ptr<Credentials> AuthNStd::getCredentials(const client::Config &conf
  * @param credentials the credentials that describe the subject of the certificate
  * @param key_pair the public/private key to be used in the certificate, only public key is used
  * @param usage certificate usage
+ * @param config the configuration for the certificate creation request
  * @return A managed shared CertCreationRequest object.
  */
 std::shared_ptr<CertCreationRequest> AuthNStd::createCertCreationRequest(const std::shared_ptr<Credentials> &credentials,
-                                                                         const std::shared_ptr<KeyPair> &key_pair, const uint16_t &usage) const {
-    auto cert_creation_request = Auth::createCertCreationRequest(credentials, key_pair, usage);
+const std::shared_ptr<KeyPair> &key_pair, const uint16_t &usage,
+const ConfigAuthN &config) const {
+    auto cert_creation_request = Auth::createCertCreationRequest(credentials, key_pair, usage, config);
 
     return cert_creation_request;
 }

--- a/certs/authn/std/authnstd.h
+++ b/certs/authn/std/authnstd.h
@@ -56,8 +56,10 @@ class AuthNStd final : public Auth {
 
     std::shared_ptr<Credentials> getCredentials(const client::Config &config, bool for_client) const override;
 
-    std::shared_ptr<CertCreationRequest> createCertCreationRequest(const std::shared_ptr<Credentials> &credentials, const std::shared_ptr<KeyPair> &key_pair,
-                                                                   const uint16_t &usage) const override;
+    std::shared_ptr<CertCreationRequest> createCertCreationRequest(const std::shared_ptr<Credentials> &credentials,
+                                                                 const std::shared_ptr<KeyPair> &key_pair,
+                                                                 const uint16_t &usage,
+                                                                 const ConfigAuthN &config) const override;
 
     bool verify(Value ccr) const override;
 

--- a/certs/authn/std/authnstdmain.cpp
+++ b/certs/authn/std/authnstdmain.cpp
@@ -39,6 +39,7 @@ void defineOptions(CLI::App &app, ConfigStd &config, bool &verbose, bool &debug,
     app.add_flag("-d,--debug", debug, "Debug mode");
     app.add_flag("-V,--version", show_version, "Print version and exit.");
     app.add_flag("--force", force, "Force overwrite if certificate exists.");
+    app.add_flag("-s,--no-status", config.no_status, "Request that status checking not be required for this certificate. PVACMS may ignore this request if it is configured to require all certificates to have status checking");
 
     app.add_flag("-D,--daemon", daemon_mode, "Daemon mode");
     app.add_flag("--add-config-uri", add_config_uri, "Add a config uri to the generated certificate");
@@ -83,6 +84,7 @@ void showHelp(const char *program_name) {
               << "        --add-config-uri                     Add a config uri to the generated certificate\n"
               << "        --config-uri-base <config_uri_base>  Specifies the config URI base to add to a certificate.  Default `CERT:CONFIG`\n"
               << "        --force                              Force overwrite if certificate exists\n"
+              << "  (-s | --no-status)                         Request that status checking not be required for this certificate\n"
               << "  (-v | --verbose)                           Verbose mode\n"
               << "  (-d | --debug)                             Debug mode\n"
               << std::endl;

--- a/certs/configcms.cpp
+++ b/certs/configcms.cpp
@@ -151,7 +151,12 @@ void ConfigCms::fromCmsEnv(const std::map<std::string, std::string> &defs) {
 
     // EPICS_PVACMS_CERTS_REQUIRE_SUBSCRIPTION
     if (pickone({"EPICS_PVACMS_CERTS_REQUIRE_SUBSCRIPTION"})) {
-        cert_status_subscription = parseTo<bool>(pickone.val);
+        if (parseTo<bool>(pickone.val)) {
+            cert_status_subscription = YES;
+        } else {
+            cert_status_subscription = NO;
+        }
+        // If value is not YES or NO, keep the default
     }
 }
 

--- a/certs/configcms.h
+++ b/certs/configcms.h
@@ -7,6 +7,7 @@
 #ifndef PVXS_CONFIGCMS_H_
 #define PVXS_CONFIGCMS_H_
 
+#include <certfactory.h>
 #include <memory>
 
 #include <pvxs/config.h>
@@ -84,12 +85,13 @@ class ConfigCms final : public server::Config {
      * A flag indicating that subscription is required and a string
      * containing the PV name to subscribe to.
      *
-     * If the flag is false certificate validity will work as normal
-     * but clients will not know that they have been revoked.
+     * If set to YES, status subscription is always required.
+     * If set to NO, status subscription is never required.
+     * If set to DEFAULT, the client's no_status flag determines whether status subscription is required.
      *
-     * Default is true
+     * Default is DEFAULT
      */
-    bool cert_status_subscription = true;
+    CertStatusSubscription cert_status_subscription{DEFAULT};
 
     /**
      * @brief This is the string that determines the fully

--- a/src/security.h
+++ b/src/security.h
@@ -95,6 +95,7 @@ struct Credentials {
         members::UInt64("not_after"),          \
         members::String("pub_key"),            \
         members::String("config_uri_base"),    \
+        members::Bool("no_status"),            \
         members::Struct("verifier", VERIFIER), \
     }
 


### PR DESCRIPTION
- Introduced `CertStatusSubscription` enum to manage certificate status subscription requirements.
- Updated `CertFactory` to utilize the new enum, allowing for more flexible subscription handling based on configuration and the `no_status` flag.
- Modified constructors and methods across various files to accommodate the new subscription logic.
- Enhanced `ConfigCms` and related classes to parse and handle the new subscription settings.
- Updated documentation to reflect changes in the subscription behavior and parameters.