### PR TITLE
Add CLI and env var support for overriding cert and LDAP params

### DIFF
--- a/example/docker/spva_std/softioc_bashrc
+++ b/example/docker/spva_std/softioc_bashrc
@@ -9,9 +9,9 @@ export PROJECT_HOME=/opt/epics
 export EPICS_PVAS_TLS_KEYCHAIN=${XDG_CONFIG_HOME}/pva/1.3/server.p12
 
 #### SETUP SOFTIOC Organisation
-# Environment: EPICS_PVAS_AUTH_ORG
+# Environment: EPICS_PVAS_AUTH_ORGANIZATION
 # Default    : <hostname>
-export EPICS_PVAS_AUTH_ORG=epics.org
+export EPICS_PVAS_AUTH_ORGANIZATION=epics.org
 
 # set path
 export PVXS_HOST_ARCH=$(${PROJECT_HOME}/epics-base/startup/EpicsHostArch)


### PR DESCRIPTION
### Description

This pull request introduces functionality to override certificate and LDAP parameters (name, organization, unit, country) via CLI arguments and environment variables. It also standardizes the handling of related variables in the `authnstd` and `authnldap` modules.
