### PR TITLE
Conditionalize jwtlogintest build on PVXS_ENABLE_JWT_AUTH

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -163,9 +163,11 @@ testtlsstatus_SRCS += certstatusmanager.cpp
 testtlsstatus_SRCS += certstatus.cpp
 TESTS += testtlsstatus
 
+ifeq ($(PVXS_ENABLE_JWT_AUTH),YES)
 TESTPROD_HOST += jwtlogintest
 jwtlogintest_SRCS += jwtlogintest.cpp
 jwtlogintest_SYS_LIBS +=curl
+endif # PVXS_ENABLE_JWT_AUTH
 
 endif # EVENT2_HAS_OPENSSL
 endif


### PR DESCRIPTION
### Description

This pull request updates the `Makefile` to conditionally build `jwtlogintest` based on the `PVXS_ENABLE_JWT_AUTH` flag. This ensures that the test is only compiled if the relevant functionality is enabled, improving build flexibility