### PR TITLE
Implement certificate status timer management in SSL monitoring

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -458,10 +458,10 @@ ContextImpl::ContextImpl(const Config& conf, const evbase tcp_loop)
       caMethod(buildCAMethod()),
       searchTx4(AF_INET, SOCK_DGRAM, 0),
       searchTx6(AF_INET6, SOCK_DGRAM, 0),
+      tcp_loop(tcp_loop),
 #ifdef PVXS_ENABLE_OPENSSL
       tls_context(nullptr),
 #endif
-      tcp_loop(tcp_loop),
       searchRx4(__FILE__, __LINE__, event_new(tcp_loop.base, searchTx4.sock, EV_READ | EV_PERSIST, &ContextImpl::onSearchS, this)),
       searchRx6(__FILE__, __LINE__, event_new(tcp_loop.base, searchTx6.sock, EV_READ | EV_PERSIST, &ContextImpl::onSearchS, this)),
       searchTimer(__FILE__, __LINE__, event_new(tcp_loop.base, -1, EV_TIMEOUT, &ContextImpl::tickSearchS, this)),

--- a/src/clientimpl.h
+++ b/src/clientimpl.h
@@ -362,6 +362,7 @@ struct ContextImpl : std::enable_shared_from_this<ContextImpl>
     // explicitly broken by Context::close(), Context::cacheClear(), or ContextImpl::cacheClean()
     // chanByName key'd by (pv, forceServer)
     std::map<std::pair<std::string, std::string>, std::shared_ptr<Channel>> chanByName;
+    const evbase tcp_loop;
 
 #ifdef PVXS_ENABLE_OPENSSL
     std::shared_ptr<ossl::SSLContext> tls_context;
@@ -382,7 +383,6 @@ struct ContextImpl : std::enable_shared_from_this<ContextImpl>
 
     std::vector<std::pair<SockEndpoint, std::shared_ptr<Connection>>> nameServers;
 
-    const evbase tcp_loop;
     const evevent searchRx4, searchRx6;
     const evevent searchTimer;
     const evevent initialSearcher;

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -170,7 +170,7 @@ struct CertStatusExData {
     // To lock changes to ex data
     epicsMutex lock;
     // The event loop to create timers for the status validity countdown
-    const evbase& loop;
+    const evbase loop;
     // The entity certificate
     ossl_ptr<X509> cert{};
     // The Trusted Root Certificate Authority
@@ -196,7 +196,7 @@ struct CertStatusExData {
      * @param status_check_enabled - Whether status checking is enabled for this context.  If not then a permanent status is set and monitoring is not
      * configured
      */
-    CertStatusExData(const evbase& loop, bool status_check_enabled) : loop(loop), status_check_enabled(status_check_enabled) {}
+    CertStatusExData(const evbase loop, const bool status_check_enabled) : loop(loop), status_check_enabled(status_check_enabled) {}
 
     /**
      * @brief Returns the CertStatusExData from the SSL_CTX
@@ -212,7 +212,7 @@ struct CertStatusExData {
      */
     static CertStatusExData* fromSSL(SSL* ssl);
 
-    void removePeerStatusAndMonitor(serial_number_t serial_number) {
+    void removePeerStatusAndMonitor(const serial_number_t serial_number) {
         Guard G(lock);
         peer_statuses.erase(serial_number);
     }

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -128,8 +128,7 @@ struct SSLPeerStatusAndMonitor {
      * @param ex_data_ptr the ex_data structure that the list of peer status and monitors is stored, for cleanup
      * @param fn function to call when the status changes
      */
-    SSLPeerStatusAndMonitor(const serial_number_t serial_number, CertStatusExData* ex_data_ptr, const std::function<void(bool)>& fn)
-        : fn(fn), serial_number{serial_number}, ex_data_ptr{ex_data_ptr} {}
+    SSLPeerStatusAndMonitor(serial_number_t serial_number, CertStatusExData* ex_data_ptr, const std::function<void(bool)>& fn);
 
     /**
      * @brief Constructor when no monitoring is needed
@@ -137,14 +136,17 @@ struct SSLPeerStatusAndMonitor {
      * @param ex_data_ptr the ex_data structure that the list of peer status and monitors is stored, for cleanup
      * @param status permanent status to set
      */
-    SSLPeerStatusAndMonitor(const serial_number_t serial_number, CertStatusExData* ex_data_ptr, const certs::CertificateStatus& status)
-        : serial_number{serial_number}, ex_data_ptr{ex_data_ptr}, status{status} {}
+    SSLPeerStatusAndMonitor(serial_number_t serial_number, CertStatusExData* ex_data_ptr, const certs::CertificateStatus& status);
 
     void updateStatus(const certs::CertificateStatus& status);
 
     // Clean up peer status and monitor
     // Also remove from peer cert status map
     ~SSLPeerStatusAndMonitor();
+    evevent status_validity_timer;
+
+    static void statusValidityTimerCallback(evutil_socket_t fd, short evt, void* raw);
+    void restartStatusValidityTimerFromCertStatus();
 
     bool isSubscribed() const { return subscribed; }
 };


### PR DESCRIPTION
Adds functionality to manage certificate status expiration  (distinct from certificate expiration) within `SSLPeerStatusAndMonitor`, including initialization, callback handling, cleanup, and restart mechanisms. Adjusts member initialization and destruction to prevent dangling references, and ensures safe management of `evbase` by copying instead of referencing it.