### PR TITLE
Add EPICS_SPVA_COMPAT_VERSION_INT for compatibility

### DIFF
--- a/ioc/securityclient.h
+++ b/ioc/securityclient.h
@@ -10,6 +10,9 @@
 #ifndef PVXS_SECURITYCLIENT_H
 #define PVXS_SECURITYCLIENT_H
 
+// The version of epics-base that first contains the new Secure PVAccess API
+#define EPICS_SPVA_COMPAT_VERSION_INT VERSION_INT(7, 0, 9, 1)
+
 #include <vector>
 #include <asLib.h>
 #include <dbChannel.h>


### PR DESCRIPTION
This pull request introduces the `EPICS_SPVA_COMPAT_VERSION_INT` for legacy epics-base asLib compatibility.  If epics version is less than the version that supports SPVA then legacy calls are made however if the version supports it, newer, more secure calls are made.  This ensures compatibility with older versions of epics-base

### Summary of Changes
- Added `EPICS_SPVA_COMPAT_VERSION_INT` for smoother integration with older epics-base asLib implementations. 
