### PR TITLE
Remove legacy compatibility code and update `SecurityClient`

### DIFF
--- a/ioc/securityclient.h
+++ b/ioc/securityclient.h
@@ -10,9 +10,6 @@
 #ifndef PVXS_SECURITYCLIENT_H
 #define PVXS_SECURITYCLIENT_H
 
-// The version of epics-base that first contains the new Secure PVAccess API
-#define EPICS_SPVA_COMPAT_VERSION_INT VERSION_INT(7, 0, 9, 1)
-
 #include <vector>
 #include <asLib.h>
 #include <dbChannel.h>


### PR DESCRIPTION
### Description

This pull request removes the `EPICS_SPVA_COMPAT_VERSION_INT` macro and associated legacy compatibility code. It updates the `SecurityClient` to use modern `asAddClientIdentity` or conditional `asAddClient` logic, improving code maintainability and alignment with current standards.
