### PR TITLE
Fix typos in documentation files

### DIFF
--- a/documentation/spvaauth.rst
+++ b/documentation/spvaauth.rst
@@ -116,7 +116,7 @@ x509 Method
 ^^^^^^^^^^^^
 
 A new Authentication Method is added with Secure PVAccess - ``x509``.
-With ``x509`` EPICS clients provde authenticated credentials in the form of an X.509 certificate.
+With ``x509`` EPICS clients provide authenticated credentials in the form of an X.509 certificate.
 
 Optionally EPICS clients can use a variety of Site Authenticators that can create an X.509 certificate from a variety of sources including
 
@@ -943,7 +943,7 @@ New Security Features
    - Certificates provide cryptographically secure identity verification
 2. **Fine-grained Control**:
 
-   - Combine authentcation ``METHOD``, certifying ``AUTHORITY``, and transport ``PROTOCOL`` for precise access control
+   - Combine authentication ``METHOD``, certifying ``AUTHORITY``, and transport ``PROTOCOL`` for precise access control
 3. **Connection Security**:
 
    - Control access based on encrypted (``TLS``) vs. unencrypted (``TCP``) connections
@@ -955,7 +955,7 @@ New Security Features
    - Support legacy clients while providing enhanced security for modern clients
 6. **Centralized Management**:
 
-   - Revocation of permisions now managed through PVACMS with immediate effect
+   - Revocation of permissions now managed through PVACMS with immediate effect
 7. **Scalable Architecture**:
 
    - Support for multiple authentication methods via Authenticators
@@ -994,7 +994,7 @@ The above rule will match any client that presents an x509 certificate to assert
 AUTHORITY
 ~~~~~~~~~
 
-1. A new top level item in ACF files AUTHORITY declares the heirarchy of Certificate Authorities that can be
+1. A new top level item in ACF files AUTHORITY declares the hierarchy of Certificate Authorities that can be
 referenced, going all the way back to the Root Certificate Authority.
 
   - Specifies Certifying Authority:
@@ -1346,7 +1346,7 @@ e.g. for Kerberos shown below.
 New APIs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Secure PVAccess introduces new APIs for programatically managing security with authenticated identities:
+Secure PVAccess introduces new APIs for programmatically managing security with authenticated identities:
 
 .. _peer_info:
 

--- a/documentation/spvacerts.rst
+++ b/documentation/spvacerts.rst
@@ -58,7 +58,7 @@ A certificate is the document that is exchanged with a peer that identifies an a
   - Care must be taken when sharing a certificate as it is stored in the same file as the private key. Do not share the keychain file with others.
 
 - A certificate is valid for a specific period of time.
-- A certificate can be revoked by an administrator (if the status monitoring extension is addded to the certificate - by default it is)
+- A certificate can be revoked by an administrator (if the status monitoring extension is added to the certificate - by default it is)
 
 Certificate Attributes
 ----------------------

--- a/src/certdate.h
+++ b/src/certdate.h
@@ -31,7 +31,7 @@ class CertTimeParseException final : public std::runtime_error {
  * .
  * Certificate Dates have a string representation `s` as well as a time_t representation `t`
  *
- * They can be parsed from stings and converted to strings.
+ * They can be parsed from strings and converted to strings.
  */
 struct CertDate {
     // time_t representation of the status date


### PR DESCRIPTION
This pull request addresses the following changes:

- Corrects typos in `certdate.h`.
- Fixes typos in `spvaauth.rst` and `spvacerts.rst`.

No functional changes were made, and this is solely a documentation improvement.