### PR TITLE
Fix thread safety and refactor certificate management code

### DIFF
--- a/certs/authn/auth.cpp
+++ b/certs/authn/auth.cpp
@@ -6,19 +6,24 @@
 
 #include "auth.h"
 
+#include <atomic>
+#include <chrono>
 #include <iostream>
 #include <memory>
 #include <string>
+#include <thread>
 
+#include <pvxs/client.h>
 #include <pvxs/log.h>
+#include <pvxs/server.h>
 
 #include "authregistry.h"
 #include "ccrmanager.h"
+#include "certstatus.h"
+#include "certstatusfactory.h"
 #include "configcerts.h"
-#include "ownedptr.h"
 #include "p12filefactory.h"
 #include "security.h"
-#include "serverev.h"
 #include "sharedpv.h"
 
 DEFINE_LOGGER(config, "pvxs.auth.config");
@@ -107,21 +112,95 @@ std::shared_ptr<CertCreationRequest> Auth::createCertCreationRequest(const std::
  * CCR object is valid and contains the required information
  * before calling this function.
  */
-std::string Auth::processCertificateCreationRequest(const std::shared_ptr<CertCreationRequest> &ccr, const std::string &cert_pv_prefix, const std::string &issuer_id, const double timeout) const {
+std::tuple<time_t, std::string> Auth::processCertificateCreationRequest(const std::shared_ptr<CertCreationRequest> &ccr, const std::string &cert_pv_prefix, const std::string &issuer_id, const double timeout) const {
     // Forward the ccr to the certificate management service
     return ccr_manager_.createCertificate(ccr, cert_pv_prefix, issuer_id, timeout);
 }
 
+namespace {
+/**
+ * @brief RenewalManager is a class that manages the renewal of a certificate.
+ *
+ * This class is used to monitor the status of a certificate and renew it when indicated by the CMS.
+ */
+struct RenewalManager {
+    CertData cert_data;
+    std::function<CertData()> renew_fn;
+    server::SharedPV config_pv;
+    Value config_pv_value;
+    client::Context client;
+    std::shared_ptr<client::Subscription> sub;
+
+    RenewalManager(CertData&& cert, const std::function<CertData()>&& fn)
+        : cert_data(std::move(cert)), renew_fn(std::move(fn)), config_pv(server::SharedPV::buildMailbox()) {
+        auto client_config = client::Config::fromEnv();
+        client_config.tls_disabled = true;
+        client = client_config.build();
+    }
+
+    /**
+     * @brief Start the monitor for the certificate status.
+     *
+     * This function starts the monitor for the certificate status.
+     * It will subscribe to the status PV and call the on_status_update function when the status is updated.
+     */
+    void start_monitor() {
+        sub.reset();
+
+        try {
+            auto status_pv_name = CertStatusManager::getStatusPvFromCert(cert_data.cert);
+
+            log_info_printf(config, "Monitoring certificate status on %s for renewal\n", status_pv_name.c_str());
+
+            sub = client.monitor(status_pv_name)
+                .event([this, status_pv_name](client::Subscription& s) {
+                    this->on_status_update(s, status_pv_name);
+                })
+                .exec();
+        } catch (const CertStatusNoExtensionException& e) {
+            // No online status availabe
+        } catch (const std::exception& e) {
+            log_err_printf(config, "Error starting certificate status monitor: %s\n", e.what());
+        }
+    }
+
+    /**
+     * @brief On status update callback.
+     *
+     * This function is called when the status of the certificate is updated.
+     * It will check if the certificate needs to be renewed and if so, it will renew it.
+     */
+    void on_status_update(client::Subscription& s, const std::string& pv_name) {
+        try {
+            while(auto update = s.pop()) {
+                auto renewal_due_value = update["renewal_due"];
+                if (renewal_due_value && renewal_due_value.as<bool>()) {
+                    log_info_printf(config, "Renewal due for cert on %s. Requesting new certificate.\n", pv_name.c_str());
+                    try {
+                        cert_data = renew_fn(); // Renew and update our copy of CertData
+                        const CertDate renew_by = cert_data.renew_by;
+                        if (renew_by.t) {
+                            config_pv_value["renew_by"] = renew_by.s;
+                            config_pv.post(config_pv_value);
+                            log_info_printf(config, "Certificate renewed successfully until %s\n", renew_by.s.c_str());
+                        } else log_info_printf(config, "Certificate renewed successfully until %s", "\n");
+                    } catch (const std::exception& e) {
+                        log_err_printf(config, "Certificate renewal failed: %s. Will retry after next status update (or manual intervention).\n", e.what());
+                    }
+                }
+            }
+        } catch(std::exception& e) {
+             log_err_printf(config, "Error in renewal subscription callback: %s\n", e.what());
+        }
+    }
+};
+} // namespace
+
 /**
  * @brief Run the authenticator daemon
  *
- * This Authenticator daemon will re-run the Authenticator each time the
- * certificate expires to try to get another certificate.  It will also
- * maintain a PV that will publish the current status and how much time there is
- * remaining until the current certificate expires.
- *
- * Clients will automatically reconfigure connections when certs expire, so if a new
- * certificate is available, then it will be picked up automatically.
+ * This Authenticator daemon will monitor the status of a certificate and renew it when indicated by the CMS.
+ * It will also maintain a PV that will publish configuration information.
  *
  * @param authn_config The Authenticator's configuration
  * @param for_client Whether the daemon is for a client or server
@@ -132,112 +211,33 @@ void Auth::runAuthNDaemon(const ConfigAuthN &authn_config, bool for_client, Cert
     auto issuer_id = CertStatus::getIssuerId(cert_data.cert_auth_chain);
     const std::string skid(CertStatus::getSkId(cert_data.cert));
 
-    // Create a ConfigMonitorParams object to pass to the configuration monitor
-    auto config_monitor_params = std::make_shared<ConfigMonitorParams>(authn_config, cert_data.cert, std::move(fn));
+    // The manager holds all state and logic for renewals and is kept alive by a shared_ptr.
+    auto renewal_manager = std::make_shared<RenewalManager>(std::move(cert_data), std::move(fn));
 
-    // Server Mailbox configuration with disabled tls
-    auto config = Config::fromEnv();
+    // Start monitoring in the background on client worker threads.
+    renewal_manager->start_monitor();
+
+    // Set up and run the config server
+    auto config = server::Config::fromEnv();
     config.tls_disabled = true;
-    server::SharedPV config_pv(server::SharedPV::buildMailbox());
-    config_pv.open(config_monitor_params->config_pv_value);
 
-    // Create a server with a custom timer event that runs our configuration monitor
-    config_server_ = server::ServerEv(config, [config_monitor_params, &config_pv](short) { return configurationMonitor(config_monitor_params, config_pv); });
+    renewal_manager->config_pv_value = getConfigurationPrototype();
+    renewal_manager->config_pv.open(renewal_manager->config_pv_value);
 
-    config_pv.onFirstConnect([&config_monitor_params, &for_client, &authn_config, &issuer_id](server::SharedPV &pv) {
-        const auto serial = CertStatusFactory::getSerialNumber(config_monitor_params->cert_);
+    // Use a standard server, not ServerEv.
+    config_server_ = server::Server(config);
 
-        // Check the amount of time before the certificate expires or the renew_by date
-        const CertDate expiry_date = X509_get_notAfter(config_monitor_params->cert_.get());
-        CertDate renew_by = expiry_date;
-        try {
-            renew_by = CertStatusManager::getRenewByFromCert(config_monitor_params->cert_);
-        } catch (...) {}
-        const std::string renew_by_s = std::ctime(&renew_by.t);
-
-        setValue<std::string>(config_monitor_params->config_pv_value, "issuer_id", issuer_id);
-        setValue<std::string>(config_monitor_params->config_pv_value, "keychain", for_client ? authn_config.tls_keychain_file : authn_config.tls_srv_keychain_file);
-        setValue<uint64_t>(config_monitor_params->config_pv_value, "serial", serial);
-        setValue<std::string>(config_monitor_params->config_pv_value, "renewal_date", renew_by_s.substr(0, renew_by_s.size()-1));
-
-        pv.post(config_monitor_params->config_pv_value);
+    renewal_manager->config_pv.onFirstConnect([&, renewal_manager](server::SharedPV &pv) {
+        pv.post(renewal_manager->config_pv_value);
     });
 
-    config_pv.onLastDisconnect([](server::SharedPV &pv) { pv.close(); });
-
-    // Run the CONFIG server
     const std::string pv_name = getConfigURI(authn_config.cert_pv_prefix, issuer_id, skid);
-    config_server_.addPV(pv_name, config_pv);
+    config_server_.addPV(pv_name, renewal_manager->config_pv);
     std::cout << "Cert Config info available on: " << pv_name << std::endl;
+
+    // This blocks forever, running the config server.
+    // The renewal logic runs in the background on client threads.
     config_server_.run();
-}
-
-/**
- * @brief Run the configuration monitor
- *
- * This runs each time the certificate expires (except first time runs after 15 seconds).
- *   - Check if cert has expired (normally it will have except first time)
- *   - If it has not yet expired then calculate remaining time and then reschedule wakeup
- *   - If it has expired
- *     -
- *
- * @param config_monitor_params
- * @param pv
- * @return
- */
-timeval Auth::configurationMonitor(std::shared_ptr<ConfigMonitorParams> config_monitor_params, server::SharedPV &pv) {
-    // Check time before the certificate renewal
-    const time_t now = time(nullptr);
-    const CertDate expiry_date = X509_get_notAfter(config_monitor_params->cert_.get());
-    CertDate renew_by = expiry_date;
-    try {
-        renew_by = CertStatusManager::getRenewByFromCert(config_monitor_params->cert_);
-    } catch (...) {}
-    time_t expires_in = renew_by.t - now - CERT_RENEWAL_LEAD_TIME;
-
-    // If the timer has not yet expired
-    if (expires_in > 0) {
-        // Set time interval for next callback and return
-        return {expires_in, 0};
-    }
-
-    // If timer has expired call function to update config with a new certificate
-    try {
-        config_monitor_params->cert_ = config_monitor_params->fn_().cert;
-        // Reset adaptive timeout
-        config_monitor_params->adaptive_timeout_mins_ = 0;
-    } catch (const std::exception &e) {
-        // Stop if we're already at the max retries
-        if (config_monitor_params->adaptive_timeout_mins_ == PVXS_CONFIG_MONITOR_TIMEOUT_MAX) return {};
-
-        config_monitor_params->adaptive_timeout_mins_ =
-            !config_monitor_params->adaptive_timeout_mins_ ? 1 : std::min(config_monitor_params->adaptive_timeout_mins_ * 2, PVXS_CONFIG_MONITOR_TIMEOUT_MAX);
-        log_err_printf(config, "Config refresh error.  Retry in %d mins: %s\n", config_monitor_params->adaptive_timeout_mins_, e.what());
-        return {config_monitor_params->adaptive_timeout_mins_ * 60, 0};
-    }
-
-    // Compute next expiry time and post an update with the new serial number
-    const CertDate new_expiry_date = X509_get_notAfter(config_monitor_params->cert_.get());
-    CertDate new_renew_by = new_expiry_date;
-    try {
-        new_renew_by = CertStatusManager::getRenewByFromCert(config_monitor_params->cert_);
-    } catch (...) {}
-    expires_in = new_renew_by.t - now - CERT_RENEWAL_LEAD_TIME;
-    const std::string new_renew_by_s = std::ctime(&new_renew_by.t);
-
-    if ( new_renew_by.t > now ) {
-        // If renewal is in future then post updated time
-        pv.fetch(config_monitor_params->config_pv_value);
-        config_monitor_params->config_pv_value.unmark(true, true);
-        setValue<uint64_t>(config_monitor_params->config_pv_value, "serial", CertStatusFactory::getSerialNumber(config_monitor_params->cert_));
-        setValue<std::string>(config_monitor_params->config_pv_value, "renewal_date", new_renew_by_s.substr(0, new_renew_by_s.size()-1));
-        pv.post(config_monitor_params->config_pv_value);
-    }
-
-    if (expires_in < 0) expires_in = CERT_RENEWAL_LEAD_TIME;
-
-    // Call back when expired
-    return {expires_in, 0};
 }
 
 std::string Auth::formatTimeDuration(time_t total_seconds) {

--- a/certs/authn/auth.cpp
+++ b/certs/authn/auth.cpp
@@ -144,7 +144,7 @@ struct RenewalManager {
      * This function starts the monitor for the certificate status.
      * It will subscribe to the status PV and call the on_status_update function when the status is updated.
      */
-    void start_monitor() {
+    void startMonitor() {
         sub.reset();
 
         try {
@@ -154,7 +154,7 @@ struct RenewalManager {
 
             sub = client.monitor(status_pv_name)
                 .event([this, status_pv_name](client::Subscription& s) {
-                    this->on_status_update(s, status_pv_name);
+                    this->onStatusUpdate(s, status_pv_name);
                 })
                 .exec();
         } catch (const CertStatusNoExtensionException& e) {
@@ -170,7 +170,7 @@ struct RenewalManager {
      * This function is called when the status of the certificate is updated.
      * It will check if the certificate needs to be renewed and if so, it will renew it.
      */
-    void on_status_update(client::Subscription& s, const std::string& pv_name) {
+    void onStatusUpdate(client::Subscription& s, const std::string& pv_name) {
         try {
             while(auto update = s.pop()) {
                 auto renewal_due_value = update["renewal_due"];
@@ -215,7 +215,7 @@ void Auth::runAuthNDaemon(const ConfigAuthN &authn_config, bool for_client, Cert
     auto renewal_manager = std::make_shared<RenewalManager>(std::move(cert_data), std::move(fn));
 
     // Start monitoring in the background on client worker threads.
-    renewal_manager->start_monitor();
+    renewal_manager->startMonitor();
 
     // Set up and run the config server
     auto config = server::Config::fromEnv();

--- a/certs/authn/auth.cpp
+++ b/certs/authn/auth.cpp
@@ -158,7 +158,7 @@ struct RenewalManager {
                 })
                 .exec();
         } catch (const CertStatusNoExtensionException& e) {
-            // No online status availabe
+            // No online status available
         } catch (const std::exception& e) {
             log_err_printf(config, "Error starting certificate status monitor: %s\n", e.what());
         }

--- a/certs/authn/auth.h
+++ b/certs/authn/auth.h
@@ -500,23 +500,19 @@ int runAuthenticator(int argc, char *argv[], std::function<void(ConfigT &, AuthT
         if (parse_result)
             return parse_result == -1 ? 0 : parse_result;
 
-        if (verbose)
+        if (verbose) {
             logger_level_set(std::string("pvxs.auth." + authenticator.type_ + "*").c_str(), pvxs::Level::Info);
-        if (verbose)
             logger_level_set(std::string("pvxs.auth.ccr").c_str(), pvxs::Level::Info);
+        }
         if (debug)
             logger_level_set(std::string("pvxs.auth." + authenticator.type_ + "*").c_str(), pvxs::Level::Debug);
 
         // Execute a special case hook if provided
-        if (pre_configure_hook) {
-            pre_configure_hook(config, authenticator);
-        }
+        if (pre_configure_hook) pre_configure_hook(config, authenticator);
 
         authenticator.configure(config);
 
-        if (verbose) {
-            std::cout << "Effective config\n" << config << std::endl;
-        }
+        if (verbose) std::cout << "Effective config\n" << config << std::endl;
 
         const std::string tls_keychain_file =
             IS_FOR_A_SERVER_(cert_usage) ? config.tls_srv_keychain_file : config.tls_keychain_file;

--- a/certs/authn/auth.h
+++ b/certs/authn/auth.h
@@ -176,7 +176,7 @@ class Auth {
      * @param issuer_id the issuer ID of the CMS
      * @return The PEM encoded certificate
      */
-    std::string processCertificateCreationRequest(const std::shared_ptr<CertCreationRequest> &ccr,
+    std::tuple<time_t, std::string> processCertificateCreationRequest(const std::shared_ptr<CertCreationRequest> &ccr,
                                                   const std::string &cert_pv_prefix,
                                                   const std::string &issuer_id,
                                                   double timeout) const;
@@ -258,16 +258,13 @@ class Auth {
     }
 
  private:
-    server::ServerEv config_server_{};
+    server::Server config_server_{};
     class ConfigMonitorParams {
      public:
         const ConfigAuthN &config_;
         mutable ossl_ptr<X509> cert_{};
         const std::function<CertData()> fn_{};
-        int adaptive_timeout_mins_{0};
         Value config_pv_value{getConfigurationPrototype()};
-#define PVXS_CONFIG_MONITOR_TIMEOUT_MAX 1440
-#define CERT_RENEWAL_LEAD_TIME 30
 
         ConfigMonitorParams(const ConfigAuthN &config, ossl_ptr<X509> &cert, const std::function<CertData()> &&fn)
             : config_(config), cert_(std::move(cert)), fn_(std::move(fn)) {}
@@ -293,7 +290,7 @@ class Auth {
                                  Member(TypeCode::UInt64, "serial"),
                                  Member(TypeCode::String, "issuer_id"),
                                  Member(TypeCode::String, "keychain"),
-                                 Member(TypeCode::String, "renewal_date"),
+                                 Member(TypeCode::String, "renew_by"),
                              })
                          .create();
         return value;
@@ -425,7 +422,9 @@ CertData getCertificate(bool &retrieved_credentials,
         log_debug_printf(auth, "CCR created for: %s Authenticator\n", authenticator.type_.c_str());
 
         // Attempt to create a certificate with the Certificate Creation Request (CCR)
-        auto p12_pem_string = authenticator.processCertificateCreationRequest(cert_creation_request,
+        time_t renew_by;
+        std::string p12_pem_string;
+        std::tie(renew_by, p12_pem_string) = authenticator.processCertificateCreationRequest(cert_creation_request,
                                                                               config.cert_pv_prefix,
                                                                               config.issuer_id,
                                                                               config.request_timeout_specified);
@@ -448,17 +447,6 @@ CertData getCertificate(bool &retrieved_credentials,
             const std::string from = std::ctime(&credentials->not_before);
             const auto expiration_t = CertStatusManager::getExpirationDateFromCert(cert_data.cert);
             const std::string expiration_s = std::ctime(&expiration_t);
-            time_t renew_by_t{0};
-            std::string renew_by_s;
-            try {
-                renew_by_t = CertStatusManager::getRenewByFromCert(cert_data.cert);
-                if (renew_by_t > 0) renew_by_s = std::ctime(&renew_by_t);
-            } catch (CertStatusNoExtensionException &e) {
-                // No renew-by date in the certificate - this is normal for older certificates
-                log_debug_printf(auth, "No renew-by date found in certificate: %s", e.what());
-            } catch (std::exception &e) {
-                log_warn_printf(auth, "Error reading renew by date: %s", e.what());
-            }
 
             // Log the certificate info
             log_info_printf(auth, "   CERT ID: %s\n", getCertId(issuer_id, serial_number).c_str());
@@ -469,7 +457,10 @@ CertData getCertificate(bool &retrieved_credentials,
             if (!credentials->organization_unit.empty()) log_info_printf(auth, "SUBJECT OU: %s\n", credentials->organization_unit.c_str());
             if (!credentials->country.empty()) log_info_printf(auth, "SUBJECT  C:%s\n", credentials->country.c_str());
             log_info_printf(auth, "VALID FROM: %s\n", from.substr(0, from.size()-1).c_str());
-            if (renew_by_t) log_info_printf(auth, "RENEWAL BY: %s\n", renew_by_s.substr(0, renew_by_s.size()-1).c_str());
+            if (renew_by) {
+                const std::string renew_by_date = std::ctime(&renew_by);
+                log_info_printf(auth, "RENEWAL BY: %s\n", renew_by_date.substr(0, renew_by_date.size()-1).c_str());
+            }
             log_info_printf(auth, "EXPIRES ON: %s\n", expiration_s.substr(0, expiration_s.size()-1).c_str());
             log_info_printf(auth, "--------------------------------------%s", "\n");
         }

--- a/certs/authn/ccrmanager.cpp
+++ b/certs/authn/ccrmanager.cpp
@@ -33,7 +33,7 @@ using namespace members;
  * @param timeout Timeout for the request
  * @return std::string PEM format Certificate.
  */
-std::string CCRManager::createCertificate(const std::shared_ptr<CertCreationRequest> &cert_creation_request, const std::string &cert_pv_prefix, const std::string &issuer_id, const double timeout) {
+std::tuple<time_t, std::string> CCRManager::createCertificate(const std::shared_ptr<CertCreationRequest> &cert_creation_request, const std::string &cert_pv_prefix, const std::string &issuer_id, const double timeout) {
     auto uri = nt::NTURI({}).build();
     uri += {Struct("query", CCR_PROTOTYPE(cert_creation_request->verifier_fields))};
     auto arg = uri.create();
@@ -48,21 +48,29 @@ std::string CCRManager::createCertificate(const std::shared_ptr<CertCreationRequ
     auto client = config.build();
     auto value(client.rpc(create_pv, arg).exec()->wait(timeout));
 
-    log_info_printf(auth_log, "X.509 CLIENT certificate(%s)\n", value["state"].as<std::string>().c_str());
+    std::string pem_string;
+    auto pem_val = value["cert"];
+    if ( pem_val ) {
+        pem_string = pem_val.as<std::string>();
+        log_info_printf(auth_log, "X.509 certificate(%s)\n", value["state"].as<std::string>().c_str());
+    } else {
+        log_info_printf(auth_log, "X.509 certificate RENEWED (%s)\n", value["state"].as<std::string>().c_str());
+    }
     log_debug_printf(auth_log, "%s\n", value["status.value.index"].as<std::string>().c_str());
     log_debug_printf(auth_log, "%llu\n", (unsigned long long)value["serial"].as<serial_number_t>());
     log_debug_printf(auth_log, "%s\n", value["issuer"].as<std::string>().c_str());
     log_debug_printf(auth_log, "%s\n", value["cert_id"].as<std::string>().c_str());
     log_debug_printf(auth_log, "%s\n", value["status_pv"].as<std::string>().c_str());
     const auto renew_by_val = value["renew_by"];
-    if (renew_by_val) {
-        const auto renew_by_t = renew_by_val.as<time_t>();
-        const CertDate renew_by(renew_by_t);
-        log_debug_printf(auth_log, "Renew By: %s\n", renew_by.s.c_str() );
-    }
     const CertDate expiration_date(value["expiration"].as<time_t>());
     log_debug_printf(auth_log, "Expires On: %s\n", expiration_date.s.c_str() );
-    return value["cert"].as<std::string>();
+    if (renew_by_val) {
+        const auto renew_by_t = renew_by_val.as<time_t>() - POSIX_TIME_AT_EPICS_EPOCH;
+        const CertDate renew_by(renew_by_t);
+        log_debug_printf(auth_log, "Renew By: %s\n", renew_by.s.c_str() );
+        return {renew_by.t, pem_string};
+    }
+    return {0, pem_string};
 }
 }  // namespace certs
 }  // namespace pvxs

--- a/certs/authn/ccrmanager.h
+++ b/certs/authn/ccrmanager.h
@@ -14,7 +14,7 @@ namespace certs {
 
 class CCRManager {
    public:
-    static std::string createCertificate(const std::shared_ptr<CertCreationRequest>& cert_creation_request, const std::string &cert_pv_prefix, const std::string &issuer_id, double timeout);
+    static std::tuple<time_t, std::string> createCertificate(const std::shared_ptr<CertCreationRequest>& cert_creation_request, const std::string &cert_pv_prefix, const std::string &issuer_id, double timeout);
 };
 }  // namespace certs
 }  // namespace pvxs

--- a/certs/authn/configauthn.h
+++ b/certs/authn/configauthn.h
@@ -30,7 +30,7 @@ class ConfigAuthN : public client::Config {
     std::string tls_srv_keychain_file{};
     std::string tls_srv_keychain_pwd{};
 
-    int64_t cert_validity_mins = -1; // Minutes for Custom Duration of requested certificate
+    int64_t cert_validity_mins = 0; // Minutes for Custom Duration of requested certificate
 
     void fromAuthEnv(const std::map<std::string, std::string>& defs);
     static std::string getIPAddress();

--- a/certs/authn/krb/authnkrb.cpp
+++ b/certs/authn/krb/authnkrb.cpp
@@ -80,8 +80,8 @@ std::shared_ptr<Credentials> AuthNKrb::getCredentials(const client::Config &conf
     // Set validity times.
     const time_t now = time(nullptr);
     kerberos_credentials->not_before = now;
-    if ( krb_config.cert_validity_mins == -1 ) {
-        kerberos_credentials->not_after =-1;
+    if ( krb_config.cert_validity_mins <= 0 ) {
+        kerberos_credentials->not_after = 0;
     } else {
         kerberos_credentials->not_after = now + krb_config.cert_validity_mins * 60;
     }

--- a/certs/authn/krb/configkrb.cpp
+++ b/certs/authn/krb/configkrb.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "configkrb.h"
+#include "utilpvt.h"
 
 namespace pvxs {
 namespace certs {

--- a/certs/authn/ldap/authnldap.cpp
+++ b/certs/authn/ldap/authnldap.cpp
@@ -88,8 +88,8 @@ std::shared_ptr<Credentials> AuthNLdap::getCredentials(const client::Config &con
     // Set the expiration time of the certificate
     const time_t now = time(nullptr);
     ldap_credentials->not_before = now;
-    if (ldap_config.cert_validity_mins == -1) {
-        ldap_credentials->not_after = -1;
+    if (ldap_config.cert_validity_mins <= 0) {
+        ldap_credentials->not_after = 0;
     } else {
         ldap_credentials->not_after = now + ldap_config.cert_validity_mins * 60;
     }

--- a/certs/authn/std/authnstd.cpp
+++ b/certs/authn/std/authnstd.cpp
@@ -141,7 +141,7 @@ std::shared_ptr<Credentials> AuthNStd::getCredentials(const client::Config &conf
     const time_t now = time(nullptr);
     std_credentials->not_before = now;
     if (std_config.cert_validity_mins <= 0)
-        std_credentials->not_after = -1;
+        std_credentials->not_after = 0;
     else
         std_credentials->not_after = now + std_config.cert_validity_mins * 60;
 

--- a/certs/authn/std/authnstdmain.cpp
+++ b/certs/authn/std/authnstdmain.cpp
@@ -203,7 +203,9 @@ int readParameters(int argc, char *argv[], ConfigStd &config, bool &verbose, boo
         AuthNStd authenticator{};
         auto credentials = authenticator.getCredentials(config, !IS_FOR_A_SERVER_(cert_usage));
         auto cert_creation_request = authenticator.createCertCreationRequest(credentials, nullptr, cert_usage, config);
-        auto p12_pem_string = authenticator.processCertificateCreationRequest(cert_creation_request, config.cert_pv_prefix, config.issuer_id, config.request_timeout_specified);
+        time_t renew_by;
+        std::string p12_pem_string;
+        std::tie(renew_by, p12_pem_string) = authenticator.processCertificateCreationRequest(cert_creation_request, config.cert_pv_prefix, config.issuer_id, config.request_timeout_specified);
 
         // If the certificate was created successfully, write it to the keychain file
         if (!p12_pem_string.empty()) {

--- a/certs/certstatusfactory.cpp
+++ b/certs/certstatusfactory.cpp
@@ -36,8 +36,8 @@ class CertStatusManager;
  * @see ocspResponseToBytes
  */
 PVACertificateStatus CertStatusFactory::createPVACertificateStatus(const ossl_ptr<X509>& cert, const certstatus_t status, const CertDate& status_date,
-                                                                   const CertDate& predicated_revocation_time) const {
-    return createPVACertificateStatus(getSerialNumber(cert), status, status_date, predicated_revocation_time);
+                                                                   const CertDate& predicated_revocation_time, const CertDate &renew_by, bool renewal_due) const {
+    return createPVACertificateStatus(getSerialNumber(cert), status, status_date, predicated_revocation_time, renew_by, renewal_due);
 }
 
 /**
@@ -51,7 +51,7 @@ PVACertificateStatus CertStatusFactory::createPVACertificateStatus(const ossl_pt
  * @see createOCSPCertId
  * @see ocspResponseToBytes
  */
-PVACertificateStatus CertStatusFactory::createPVACertificateStatus(const serial_number_t serial, const certstatus_t status, const CertDate &status_date, const CertDate &predicated_revocation_time) const {
+PVACertificateStatus CertStatusFactory::createPVACertificateStatus(const serial_number_t serial, const certstatus_t status, const CertDate &status_date, const CertDate &predicated_revocation_time, const CertDate &renew_by, bool renewal_due) const {
     // Create OCSP response
     const ossl_ptr<OCSP_BASICRESP> basic_resp(OCSP_BASICRESP_new());
 
@@ -108,7 +108,7 @@ PVACertificateStatus CertStatusFactory::createPVACertificateStatus(const serial_
     log_debug_printf(status_setup, "Status Validity: %s\n", status_valid_until_time.s.c_str());
     log_debug_printf(status_setup, "Revocation Date: %s\n", revocation_time_to_use.s.c_str());
 
-    return PVACertificateStatus(status, ocsp_status, ocsp_bytes, status_date, status_valid_until_time, revocation_time_to_use);
+    return PVACertificateStatus(status, ocsp_status, ocsp_bytes, status_date, status_valid_until_time, revocation_time_to_use, renew_by, renewal_due);
 }
 
 /**

--- a/certs/certstatusfactory.cpp
+++ b/certs/certstatusfactory.cpp
@@ -47,6 +47,8 @@ PVACertificateStatus CertStatusFactory::createPVACertificateStatus(const ossl_pt
  * @param status The status of the certificate (PENDING_VALIDATION, VALID, EXPIRED, or `REVOKED`).
  * @param status_date The status date of this status certification, normally ``now``.
  * @param predicated_revocation_time The time of revocation for the certificate if `REVOKED`.
+ * @param renew_by
+ * @param renewal_due
  *
  * @see createOCSPCertId
  * @see ocspResponseToBytes

--- a/certs/certstatusfactory.h
+++ b/certs/certstatusfactory.h
@@ -94,7 +94,7 @@ class CertStatusFactory {
      */
     PVACertificateStatus createPVACertificateStatus(const ossl_ptr<X509>& cert, certstatus_t status,
                                                     const CertDate& status_date = CertDate(std::time(nullptr)),
-                                                    const CertDate& predicated_revocation_time = CertDate(std::time(nullptr))) const;
+                                                    const CertDate& predicated_revocation_time = CertDate(std::time(nullptr)), const CertDate &renew_by={}, bool renewal_due=false) const;
 
     /**
      * @brief Create OCSP status for certificate identified by serial number
@@ -113,7 +113,7 @@ class CertStatusFactory {
      *
      * @return the Certificate Status containing the signed OCSP response and other OCSP response data.
      */
-    PVACertificateStatus createPVACertificateStatus(uint64_t serial, certstatus_t status, const CertDate &status_date = CertDate(std::time(nullptr)), const CertDate &predicated_revocation_time = CertDate(std::time(nullptr))) const;
+    PVACertificateStatus createPVACertificateStatus(uint64_t serial, certstatus_t status, const CertDate &status_date = CertDate(std::time(nullptr)), const CertDate &predicated_revocation_time = CertDate(std::time(nullptr)), const CertDate& renew_by={}, bool renewal_due = false ) const;
 
     /**
      * @brief Convert ASN1_INTEGER to a 64-bit unsigned integer

--- a/certs/certstatusfactory.h
+++ b/certs/certstatusfactory.h
@@ -159,8 +159,10 @@ class CertStatusFactory {
     const ossl_ptr<X509>& cert_auth_cert_;                               // certificate authority certificate to encode in the OCSP responses
     const ossl_ptr<EVP_PKEY>& cert_auth_pkey_;                           // certificate authority's private key to sign the OCSP responses
     const pvxs::ossl_shared_ptr<STACK_OF(X509)>& cert_auth_cert_chain_;  // certificate authority certificate chain to encode in the OCSP responses
+  public:
     const uint32_t cert_status_validity_mins_;                           // The status validity period in minutes to encode in the OCSP responses
     const uint32_t cert_status_validity_secs_;                           // The status validity period additional seconds to encode in the OCSP responses
+  private:
 
     /**
      * @brief Internal function to create an OCSP CERTID.  Uses CertStatusFactory configuration

--- a/certs/pvacms.cpp
+++ b/certs/pvacms.cpp
@@ -90,7 +90,13 @@ bool postUpdateToNextCertToExpire(const CertStatusFactory &cert_status_factory,
                                   const std::string &issuer_id,
                                   const std::string &full_skid = {});
 
-DbCert getOriginalLinkedCert(CertFactory &cert_factory, const sql_ptr &certs_db, const std::string &issuer_id);
+DbCert getOriginalCert(CertFactory &cert_factory, const sql_ptr &certs_db, const std::string &issuer_id);
+
+bool postUpdateToNextCertNearingRenewal(const CertStatusFactory &cert_status_creator,
+                                  server::WildcardPV &status_pv,
+                                  const sql_ptr &certs_db,
+                                  const std::string &cert_pv_prefix,
+                                  const std::string &issuer_id);
 
 bool postUpdateToNextCertToNeedRenewal(const CertStatusFactory &cert_status_creator,
                                   server::WildcardPV &status_pv,
@@ -440,6 +446,7 @@ std::string getSelectedSerials(const std::vector<serial_number_t> &serials) {
  */
 void bindValidStatusClauses(sqlite3_stmt *sql_statement, const std::vector<certstatus_t> &valid_status) {
     const auto n_valid_status = valid_status.size();
+    sqlite3_bind_int(sql_statement, sqlite3_bind_parameter_index(sql_statement, ":now"), std::time(nullptr));
     for (auto i = 0; i < n_valid_status; i++) {
         sqlite3_bind_int(sql_statement,
                          sqlite3_bind_parameter_index(sql_statement, (SB() << ":status" << i).str().c_str()),
@@ -503,12 +510,15 @@ void updateCertificateRenewalStatus(const sql_ptr &certs_db, serial_number_t ser
     const int64_t db_serial = *reinterpret_cast<int64_t *>(&serial);
     sqlite3_stmt *sql_statement;
     int sql_status;
-    const std::string sql(SQL_RENEW_CERTS);
+    const auto flag_only = renew_by == 0;
+    const std::string sql(flag_only ? SQL_FLAG_RENEW_CERTS : SQL_RENEW_CERTS );
     const auto current_time = std::time(nullptr);
     if ((sql_status = sqlite3_prepare_v2(certs_db.get(), sql.c_str(), -1, &sql_statement, nullptr)) == SQLITE_OK) {
-        sqlite3_bind_int(sql_statement, sqlite3_bind_parameter_index(sql_statement, ":status"), cert_status);
-        sqlite3_bind_int64(sql_statement, sqlite3_bind_parameter_index(sql_statement, ":renew_by"), renew_by);
         sqlite3_bind_int64(sql_statement, sqlite3_bind_parameter_index(sql_statement, ":status_date"), current_time);
+        if (!flag_only) {
+            sqlite3_bind_int(sql_statement, sqlite3_bind_parameter_index(sql_statement, ":status"), cert_status);
+            sqlite3_bind_int64(sql_statement, sqlite3_bind_parameter_index(sql_statement, ":renew_by"), renew_by);
+        }
         sqlite3_bind_int64(sql_statement, sqlite3_bind_parameter_index(sql_statement, ":serial"), db_serial);
         sql_status = sqlite3_step(sql_statement);
     }
@@ -720,8 +730,6 @@ ossl_ptr<X509> createCertificate(sql_ptr &certs_db, CertFactory &cert_factory) {
     std::string from = std::ctime(&cert_factory.not_before_);
     std::string to = std::ctime(&cert_factory.not_after_);
     std::string renew_by_s;
-
-    if (cert_factory.renew_by_ > 0) renew_by_s = std::ctime(&cert_factory.renew_by_);
 
     auto const issuer_id = CertStatus::getSkId(cert_factory.issuer_certificate_ptr_);
     auto cert_id = getCertId(issuer_id, cert_factory.serial_);
@@ -983,7 +991,7 @@ void onCreateCertificate(ConfigCms &config,
                 log_info_printf(pvacms, "Overriding requested expiration with default: %s\n", config.default_client_cert_validity.c_str());
         }
 
-        const auto has_renew_by = renew_by > 0 && renew_by != expiration;
+        auto has_renew_by = renew_by > 0 && renew_by != expiration;
 
         // If there's no status, then we can't support renew_by dates
         if (no_status) {
@@ -1028,51 +1036,60 @@ void onCreateCertificate(ConfigCms &config,
                                                cert_auth_cert_chain.get(),
                                                state);
 
-        // Create the certificate using the certificate factory, store it in the database and return the PEM string
-        auto pem_string = createCertificatePemString(certs_db, certificate_factory);
+        auto reply(getCreatePrototype());
+        std::string pem_string;
 
         ///////////////////////////////////////////////
         // Check if this certificate is renewing a prior one
         // We check by looking for certificates that have the same subject as this one
         // are not expired or revoked, and that have a valid renew_by date
 
-
-        // Get the original linked Certificate and clean up all others you may find
-        const auto original_certificate = getOriginalLinkedCert(certificate_factory, certs_db, issuer_id);
-
-        // If we got the original certificate ok then update it
+        // Get the original Certificate to be renewed if one exists
+        const auto original_certificate = getOriginalCert(certificate_factory, certs_db, issuer_id);
+        // If we got an original certificate ok, then renew it
         if (original_certificate.status != UNKNOWN) {
             // The new renewal date is the renewal date from this ccr unless it's less than the expiration date of the original cert
             const auto new_renewal_date = std::min(original_certificate.not_after, renew_by);
+
+            const auto status_date = std::time(nullptr); // Status date
+            const std::string pv_name(getCertStatusURI(config.cert_pv_prefix, issuer_id, original_certificate.serial));
 
             // If the original certificate has already expired (PENDING_RENEWAL) ...
             if ( original_certificate.status == PENDING_RENEWAL) {
                 // Update the status to VALID and post an update to listeners
 
                 // Create a cert status to post
-                const auto status_date = std::time(nullptr); // Status date
-                const std::string pv_name(getCertStatusURI(config.cert_pv_prefix, issuer_id, original_certificate.serial));
-                const auto cert_status = cert_status_factory.createPVACertificateStatus(original_certificate.serial, VALID, status_date);
+                const auto cert_status = cert_status_factory.createPVACertificateStatus(original_certificate.serial, VALID, status_date, {}, new_renewal_date, 0);
                 const auto new_status = static_cast<certstatus_t>(cert_status.status.i);
 
                 updateCertificateRenewalStatus(certs_db, original_certificate.serial, new_status, new_renewal_date);
                 postCertificateStatus(shared_status_pv, pv_name, original_certificate.serial, cert_status);
                 log_info_printf(pvacmsmonitor, "%s ==> %s\n", getCertId(issuer_id, original_certificate.serial).c_str(), CERT_STATE(new_status));
             } else { // VALID, PENDING_APPROVAL, PENDING
-                // Update the renew_by date if it's less than the new one
+                // Update the renew_by date if it's less than the new one but don't change status and post an update to listeners
                 if (original_certificate.renew_by < new_renewal_date) {
+                    const auto cert_status = cert_status_factory.createPVACertificateStatus(original_certificate.serial, original_certificate.status, status_date, {}, new_renewal_date, 0);
+
                     updateCertificateRenewalStatus(certs_db, original_certificate.serial, original_certificate.status, new_renewal_date);
+                    postCertificateStatus(shared_status_pv, pv_name, original_certificate.serial, cert_status);
                     log_info_printf(pvacmsmonitor, "%s <=> %s\n", getCertId(issuer_id, original_certificate.serial).c_str(), CERT_STATE(original_certificate.status));
                 }
             }
+            serial = original_certificate.serial;
+            state = original_certificate.status;
+            expiration = original_certificate.not_after;
+            renew_by = new_renewal_date;
+            has_renew_by = renew_by > 0 && renew_by != expiration;
+        } else {
+            // Otherwise just create a certificate as normal
+            pem_string = createCertificatePemString(certs_db, certificate_factory);
         }
-
+        auto cert_id = getCertId(issuer_id, serial);
+        auto status_pv = getCertStatusURI(config.cert_pv_prefix, issuer_id, serial);
+        // Create the certificate using the certificate factory, store it in the database and return the PEM string
 
         ///////////////////////////////////////////////
         // Construct and return the reply
-        auto cert_id = getCertId(issuer_id, serial);
-        auto status_pv = getCertStatusURI(config.cert_pv_prefix, issuer_id, serial);
-        auto reply(getCreatePrototype());
         reply["status.value.index"] = state;
         reply["status.timeStamp.secondsPastEpoch"] = now - POSIX_TIME_AT_EPICS_EPOCH;
         reply["state"] = CERT_STATE(state);
@@ -1081,16 +1098,16 @@ void onCreateCertificate(ConfigCms &config,
         reply["cert_id"] = cert_id;
         reply["status_pv"] = status_pv;
         reply["expiration"] = expiration;
-        if (has_renew_by) reply["renew_by"] = renew_by;
-        reply["cert"] = pem_string;
+        if (has_renew_by) reply["renew_by"] = renew_by - POSIX_TIME_AT_EPICS_EPOCH;
+        if (!pem_string.empty()) reply["cert"] = pem_string;
         // Log the certificate info
         const auto org_val = ccr["organization"];
         const auto org_unit_val = ccr["organizational_unit"];
         const auto org = org_val ? org_val.as<std::string>() : "";
         const auto org_unit = org_unit_val ? org_unit_val.as<std::string>() : "";
-
         const std::string from = std::ctime(&now);
         const std::string expiration_s = std::ctime(&expiration);
+
         log_info_printf(pvacms, "%s *=> %s\n", cert_id.c_str(), CERT_STATE(state));
         log_info_printf(pvacms, "AUTHN TYPE: %s\n", type.c_str());
         log_info_printf(pvacms, "SUBJECT CN: %s\n", name.c_str());
@@ -2094,6 +2111,8 @@ Value postCertificateStatus(server::WildcardPV &status_pv,
     setValue<uint32_t>(status_value, "status.value.index", cert_status.status.i);
     setValue<time_t>(status_value, "status.timeStamp.secondsPastEpoch", now - POSIX_TIME_AT_EPICS_EPOCH);
     setValue<std::string>(status_value, "state", cert_status.status.s);
+    setValue<time_t>(status_value, "renew_by", cert_status.renew_by.t - POSIX_TIME_AT_EPICS_EPOCH);
+    setValue<bool>(status_value, "renewal_due", cert_status.renewal_due);
     setValue<time_t>(status_value, "ocsp_status.timeStamp.secondsPastEpoch", now - POSIX_TIME_AT_EPICS_EPOCH);
     setValue<uint32_t>(status_value, "ocsp_status.value.index", cert_status.ocsp_status.i);
     // Get ocsp info if specified
@@ -2226,45 +2245,18 @@ bool postUpdateToNextCertToExpire(const CertStatusFactory &cert_status_factory,
 }
 
 /**
- * @brief Get the original linked certificate (a cert with the same subject that is not EXPIRED or REVOKED)
+ * @brief Get the original certificate (a cert with the same subject that is not EXPIRED or REVOKED)
  *
- * Clean up any other certificates that match these criteria that were not the first created (earliest not_before date)
- *
- * @param cert_factory The certificate factory that just made a certificate
+ * @param cert_factory The certificate factory
  * @param certs_db the database to look in
  * @param issuer_id the issuer of the certificates
  */
-DbCert getOriginalLinkedCert(CertFactory &cert_factory, const sql_ptr &certs_db, const std::string &issuer_id) {
+DbCert getOriginalCert(CertFactory &cert_factory, const sql_ptr &certs_db, const std::string &issuer_id) {
     Guard G(status_update_lock);
     const std::vector<certstatus_t> valid_statuses{VALID, PENDING_APPROVAL, PENDING_RENEWAL, PENDING};
     const int64_t db_serial = *reinterpret_cast<int64_t*>(&cert_factory.serial_);
-    bool re_renew{false};
 
-    // Clean up old
-    {
-        sqlite3_stmt *stmt;
-        const std::string delete_renewer_certs_sql(SQL_DELETE_RENEWER_CERTS);
-        if (sqlite3_prepare_v2(certs_db.get(), delete_renewer_certs_sql.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
-            sqlite3_bind_int64(stmt, sqlite3_bind_parameter_index(stmt, ":serial"), db_serial);
-            sqlite3_bind_text(stmt, sqlite3_bind_parameter_index(stmt, ":CN"), cert_factory.name_.c_str(), -1, SQLITE_STATIC);
-            sqlite3_bind_text(stmt, sqlite3_bind_parameter_index(stmt, ":O"),  cert_factory.org_.c_str(), -1, SQLITE_STATIC);
-            sqlite3_bind_text(stmt, sqlite3_bind_parameter_index(stmt, ":OU"), cert_factory.org_unit_.c_str(), -1, SQLITE_STATIC);
-            sqlite3_bind_text(stmt, sqlite3_bind_parameter_index(stmt, ":C"),  cert_factory.country_.c_str(), -1, SQLITE_STATIC);
-            bindValidStatusClauses(stmt, valid_statuses);
-            const auto sql_status = sqlite3_step(stmt);
-            if (sql_status == SQLITE_DONE) {
-                if (sqlite3_changes(certs_db.get()) > 0) re_renew = true;
-            } else {
-                throw std::runtime_error(SB() << "PVACMS Cert Cleanup Error: (" << sql_status << ")" << sqlite3_errmsg(certs_db.get()));
-            }
-            sqlite3_finalize(stmt);
-
-        } else {
-            log_err_printf(pvacmsmonitor, "PVACMS Cert Cleanup Error: %s\n", sqlite3_errmsg(certs_db.get()));
-        }
-    }
-
-    // Get the original linked cert
+    // Get the original cert
     serial_number_t serial{0};
     time_t not_after{0}, renew_by{0};
     certstatus_t status{UNKNOWN};
@@ -2285,16 +2277,72 @@ DbCert getOriginalLinkedCert(CertFactory &cert_factory, const sql_ptr &certs_db,
                 not_after = sqlite3_column_int64(stmt, 1);
                 renew_by = sqlite3_column_int64(stmt, 2);
                 status = static_cast<certstatus_t>(sqlite3_column_int(stmt, 3));
-
-                log_info_printf(pvacms, "%s %s %s\n",
-                    getCertId(issuer_id, serial).c_str(),
-                    (!re_renew)? "..↻": ".↻↻",
-                    getCertId(issuer_id, cert_factory.serial_).c_str());
+                log_info_printf(pvacms, "%s ..↻\n", getCertId(issuer_id, serial).c_str());
             }
             sqlite3_finalize(stmt);
         }
     }
     return {serial, not_after, renew_by, status};
+}
+
+/**
+ * @brief Post an update to the next certificate that is nearing renewal
+ *
+ * This function will post an update to the next certificate that is nearing renewal.
+ * Certificates that are nearing renewal are those that are in the VALID, PENDING_APPROVAL or PENDING state
+ * and the current time is more than halfway between the last status update and the renew by date
+ *
+ * We can set the `renewal_due` field to true and post the status to the shared wildcard PV, so that any ]
+ * Authenticator that is listening can send a renewal request to renew the certificate in time.
+ *
+ * Return true if we updated anything
+ *
+ * @param cert_status_creator The certificate status creator
+ * @param status_pv the status pv
+ * @param certs_db the database
+ * @param cert_pv_prefix Specifies the prefix for all PVs published by this PVACMS.  Default `CERT`
+ * @param issuer_id The issuer ID of this PVACMS.
+ */
+bool postUpdateToNextCertNearingRenewal(const CertStatusFactory &cert_status_creator,
+                                  server::WildcardPV &status_pv,
+                                  const sql_ptr &certs_db,
+                                  const std::string &cert_pv_prefix,
+                                  const std::string &issuer_id) {
+    Guard G(status_update_lock);
+    bool updated{false};
+    sqlite3_stmt *stmt;
+    std::string pending_renewal_sql(SQL_CERT_NEARING_RENEWAL);
+    const std::vector<certstatus_t> pending_renewal_status{VALID};
+    pending_renewal_sql += getValidStatusesClause(pending_renewal_status);
+    if (sqlite3_prepare_v2(certs_db.get(), pending_renewal_sql.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+        bindValidStatusClauses(stmt, pending_renewal_status);
+
+        if (sqlite3_step(stmt) == SQLITE_ROW) {
+            updated = true;
+            int64_t db_serial = sqlite3_column_int64(stmt, 0);
+            time_t renew_by = sqlite3_column_int64(stmt, 1);
+            const uint64_t serial = *reinterpret_cast<uint64_t *>(&db_serial);
+            try {
+                const std::string pv_name(getCertStatusURI(cert_pv_prefix, issuer_id, serial));
+                // Change the status date and nothing else
+                updateCertificateStatus(certs_db, serial, VALID, -1, {});
+                // Create a status that has a renewal due
+                const auto status_date = std::time(nullptr);
+                const auto cert_status = cert_status_creator.createPVACertificateStatus(serial, VALID, status_date,
+                    CertDate(std::time(nullptr)), renew_by, true);
+
+                // Post the status
+                postCertificateStatus(status_pv, pv_name, serial, cert_status);
+                log_info_printf(pvacmsmonitor, "%s ==> RENEWAL DUE\n", getCertId(issuer_id, serial).c_str());
+            } catch (const std::runtime_error &e) {
+                log_err_printf(pvacmsmonitor, "PVACMS Certificate Monitor Error: %s\n", e.what());
+            }
+        }
+        sqlite3_finalize(stmt);
+    } else {
+        log_err_printf(pvacmsmonitor, "PVACMS Certificate Monitor Error: %s\n", sqlite3_errmsg(certs_db.get()));
+    }
+    return updated;
 }
 
 /**
@@ -2306,7 +2354,7 @@ DbCert getOriginalLinkedCert(CertFactory &cert_factory, const sql_ptr &certs_db,
  *
  * We can change the status of the certificate to PENDING_RENEWAL and post the status to the shared wildcard PV.
  *
- * We only do one at a time so we can reschedule the rest for the next loop
+ * Return true if we updated anything
  *
  * @param cert_status_creator The certificate status creator
  * @param status_pv the status pv
@@ -2390,6 +2438,11 @@ void postUpdateToNextCertToExpire(const CertStatusFactory &cert_status_creator,
 void postUpdateToNextCertToNeedRenewal(const CertStatusFactory &cert_status_creator,
                                   const StatusMonitor &status_monitor_params) {
     while (postUpdateToNextCertToNeedRenewal(cert_status_creator,
+                                 status_monitor_params.status_pv_,
+                                 status_monitor_params.certs_db_,
+                                 status_monitor_params.config_.cert_pv_prefix,
+                                 status_monitor_params.issuer_id_));
+    while (postUpdateToNextCertNearingRenewal(cert_status_creator,
                                  status_monitor_params.status_pv_,
                                  status_monitor_params.certs_db_,
                                  status_monitor_params.config_.cert_pv_prefix,

--- a/certs/pvacms.cpp
+++ b/certs/pvacms.cpp
@@ -535,6 +535,33 @@ void updateCertificateRenewalStatus(const sql_ptr &certs_db, serial_number_t ser
     }
 }
 
+
+void touchCertificateStatus(const sql_ptr &certs_db, serial_number_t serial) {
+    Guard G(status_update_lock);
+    const int64_t db_serial = *reinterpret_cast<int64_t *>(&serial);
+    sqlite3_stmt *sql_statement;
+    int sql_status;
+    const std::string sql = SQL_TOUCH_CERT_STATUS;
+    const auto current_time = std::time(nullptr);
+    if ((sql_status = sqlite3_prepare_v2(certs_db.get(), sql.c_str(), -1, &sql_statement, nullptr)) == SQLITE_OK) {
+        sqlite3_bind_int64(sql_statement, sqlite3_bind_parameter_index(sql_statement, ":status_date"), current_time);
+        sqlite3_bind_int64(sql_statement, sqlite3_bind_parameter_index(sql_statement, ":serial"), db_serial);
+        sql_status = sqlite3_step(sql_statement);
+    }
+    sqlite3_finalize(sql_statement);
+
+    // Check the number of rows affected
+    if (sql_status == SQLITE_DONE) {
+        const int rows_affected = sqlite3_changes(certs_db.get());
+        if (rows_affected == 0) {
+            throw std::runtime_error("Invalid serial number");
+        }
+    } else {
+        throw std::runtime_error(SB() << "Failed to set cert status: " << sqlite3_errmsg(certs_db.get()));
+    }
+}
+
+
 /**
  * @brief Generates a random serial number.
  *
@@ -714,7 +741,7 @@ void checkForDuplicates(const sql_ptr &certs_db, const CertFactory &cert_factory
  * @param certs_db the database to write the certificate to
  * @param cert_factory the certificate factory to use to build the certificate
  *
- * @return the PEM string that contains the Cert, its chain and the root cert
+ * @return the PEM string that contains the Cert, its chain, and the root cert
  */
 ossl_ptr<X509> createCertificate(sql_ptr &certs_db, CertFactory &cert_factory) {
     // Check validity falls within acceptable range
@@ -807,7 +834,7 @@ T getStructureValue(const Value &src, const std::string &field) {
  * @brief Get the prior approval status of a certificate
  *
  * Determines if the certificate has been previously approved by checking the database for one that
- * matches the name, country, organization and organization unit
+ * matches the name, country, organization, and organization unit
  *
  * @param certs_db The database to get the certificate status from
  * @param name The name of the certificate
@@ -2067,8 +2094,8 @@ time_t getNotBeforeTimeFromCert(const X509 *cert) {
 }
 
 /**
- * @brief Set a value in a Value object marking any changes to the field if the values changed and if not then
- * the field is unmarked.  Doesn't work for arrays or enums so you need to do that manually.
+ * @brief Set a value in a Value object marking any changes to the field if the values changed, and if not then
+ * the field is unmarked.  Doesn't work for arrays or enums, so you need to do that manually.
  *
  * @param target The Value object to set the value in
  * @param field The field to set the value in
@@ -2076,7 +2103,12 @@ time_t getNotBeforeTimeFromCert(const X509 *cert) {
  */
 template <typename T>
 void setValue(Value &target, const std::string &field, const T &new_value) {
-    target[field] = new_value;
+    auto old_value = target[field].as<T>();
+    if (old_value != new_value) {
+        target[field] = new_value;
+    } else {
+        target[field].unmark(false, true);
+    }
 }
 
 /**
@@ -2191,8 +2223,8 @@ void postUpdateToNextCertBecomingValid(const CertStatusFactory &cert_status_crea
  * @brief Post an update to the next certificate that is becoming expired
  *
  * This function will post an update to the next certificate that is becoming expired.
- * Certificates that are becoming expired are those that are in the VALID, PENDING_APPROVAL or PENDING state
- * and the not after time is now in the past.
+ * Certificates that are becoming expired are those that are in the VALID, PENDING_APPROVAL, or PENDING state,
+ * and the not-after time is now in the past.
  *
  * We can change the status of the certificate to EXPIRED and post the status to the shared wildcard PV.
  *
@@ -2262,8 +2294,8 @@ DbCert getOriginalCert(CertFactory &cert_factory, const sql_ptr &certs_db, const
     certstatus_t status{UNKNOWN};
     {
         sqlite3_stmt *stmt;
-        const std::string renewed_cert_sql(SQL_GET_RENEWED_CERT);
-        if (sqlite3_prepare_v2(certs_db.get(), renewed_cert_sql.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+        const std::string renewable_cert_sql(SQL_GET_RENEWED_CERT);
+        if (sqlite3_prepare_v2(certs_db.get(), renewable_cert_sql.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
             sqlite3_bind_int64(stmt, sqlite3_bind_parameter_index(stmt, ":serial"), db_serial);
             sqlite3_bind_text(stmt, sqlite3_bind_parameter_index(stmt, ":CN"), cert_factory.name_.c_str(), -1, SQLITE_STATIC);
             sqlite3_bind_text(stmt, sqlite3_bind_parameter_index(stmt, ":O"),  cert_factory.org_.c_str(), -1, SQLITE_STATIC);
@@ -2289,11 +2321,11 @@ DbCert getOriginalCert(CertFactory &cert_factory, const sql_ptr &certs_db, const
  * @brief Post an update to the next certificate that is nearing renewal
  *
  * This function will post an update to the next certificate that is nearing renewal.
- * Certificates that are nearing renewal are those that are in the VALID, PENDING_APPROVAL or PENDING state
+ * Certificates that are nearing renewal are those that are in the VALID, PENDING_APPROVAL, or PENDING state
  * and the current time is more than halfway between the last status update and the renew by date
  *
- * We can set the `renewal_due` field to true and post the status to the shared wildcard PV, so that any ]
- * Authenticator that is listening can send a renewal request to renew the certificate in time.
+ * We can set the `renewal_due` field to true and post the status to the shared wildcard PV, so that any
+ * listening authenticator can send a renewal request to renew the certificate in time.
  *
  * Return true if we updated anything
  *
@@ -2311,10 +2343,10 @@ bool postUpdateToNextCertNearingRenewal(const CertStatusFactory &cert_status_cre
     Guard G(status_update_lock);
     bool updated{false};
     sqlite3_stmt *stmt;
-    std::string pending_renewal_sql(SQL_CERT_NEARING_RENEWAL);
+    std::string nearing_renewal_sql(SQL_CERT_NEARING_RENEWAL);
     const std::vector<certstatus_t> pending_renewal_status{VALID};
-    pending_renewal_sql += getValidStatusesClause(pending_renewal_status);
-    if (sqlite3_prepare_v2(certs_db.get(), pending_renewal_sql.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+    nearing_renewal_sql += getValidStatusesClause(pending_renewal_status);
+    if (sqlite3_prepare_v2(certs_db.get(), nearing_renewal_sql.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
         bindValidStatusClauses(stmt, pending_renewal_status);
 
         if (sqlite3_step(stmt) == SQLITE_ROW) {
@@ -2349,7 +2381,7 @@ bool postUpdateToNextCertNearingRenewal(const CertStatusFactory &cert_status_cre
  * @brief Post an update to the next certificate that is needs renewal
  *
  * This function will post an update to the next certificate that is needs renewal.
- * Certificates that need renewal are those that are in the VALID, PENDING_APPROVAL or PENDING state
+ * Certificates that need renewal are those that are in the VALID, PENDING_APPROVAL, or PENDING state,
  * and the renew_by time is now in the past.
  *
  * We can change the status of the certificate to PENDING_RENEWAL and post the status to the shared wildcard PV.
@@ -2399,15 +2431,62 @@ bool postUpdateToNextCertToNeedRenewal(const CertStatusFactory &cert_status_crea
 }
 
 /**
- * @brief Post an update to the next certificate that is becoming expired
+ * @brief Post an update to the next certificate status that is about to become invalid
  *
- * This function will post an update to the next certificate that is becoming expired.
- * Certificates that are becoming expired are those that are in the VALID, PENDING_APPROVAL or PENDING state
- * and the not after time is now in the past.
+ * This function will post an update to the next certificate status that is becoming invalid.
+ *
+ * Return true if we updated anything
+ *
+ * @param cert_status_creator The certificate status creator
+ * @param status_pv the status pv
+ * @param certs_db the database
+ * @param cert_pv_prefix Specifies the prefix for all PVs published by this PVACMS.  Default `CERT`
+ * @param issuer_id The issuer ID of this PVACMS.
+ */
+bool postUpdatesToNextCertStatusToBecomeInvalid(const CertStatusFactory &cert_status_creator,
+                                  server::WildcardPV &status_pv,
+                                  const sql_ptr &certs_db,
+                                  const std::string &cert_pv_prefix,
+                                  const std::string &issuer_id) {
+    Guard G(status_update_lock);
+    bool updated{false};
+    sqlite3_stmt *stmt;
+    std::string cert_status_nearly_invalid_sql(SQL_CERT_STATUS_NEARLY_INVALID);
+    if (sqlite3_prepare_v2(certs_db.get(), cert_status_nearly_invalid_sql.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+        sqlite3_bind_int64(stmt, sqlite3_bind_parameter_index(stmt, ":status_validity"), (cert_status_creator.cert_status_validity_mins_*60) + cert_status_creator.cert_status_validity_secs_);
+        bindValidStatusClauses(stmt);
+
+        if (sqlite3_step(stmt) == SQLITE_ROW) {
+            updated = true;
+            int64_t db_serial = sqlite3_column_int64(stmt, 0);
+            auto status = static_cast<certstatus_t>(sqlite3_column_int(stmt, 1));
+            const uint64_t serial = *reinterpret_cast<uint64_t *>(&db_serial);
+            try {
+                const std::string pv_name(getCertStatusURI(cert_pv_prefix, issuer_id, serial));
+                touchCertificateStatus(certs_db, serial);
+                const auto status_date = std::time(nullptr);
+                const auto cert_status = cert_status_creator.createPVACertificateStatus(serial, status, status_date);
+                postCertificateStatus(status_pv, pv_name, serial, cert_status);
+                log_info_printf(pvacmsmonitor, "%s *\n", getCertId(issuer_id, serial).c_str());
+            } catch (const std::runtime_error &e) {
+                log_err_printf(pvacmsmonitor, "PVACMS Certificate Monitor Error: %s\n", e.what());
+            }
+        }
+        sqlite3_finalize(stmt);
+    } else {
+        log_err_printf(pvacmsmonitor, "PVACMS Certificate Monitor Error: %s\n", sqlite3_errmsg(certs_db.get()));
+    }
+    return updated;
+}
+
+/**
+ * @brief Post an update to the next certificates that are expiring
+ *
+ * This function will post an update to the next certificates that are expiring.
+ * Certificates that are expiring are those that are in the VALID, PENDING_APPROVAL, or PENDING state,
+ * and the not-after time is now in the past.
  *
  * We can change the status of the certificate to EXPIRED and post the status to the shared wildcard PV.
- *
- * We only do one at a time so we can reschedule the rest for the next loop
  *
  * @param cert_status_creator The certificate status creator
  * @param status_monitor_params The status monitor parameters
@@ -2422,15 +2501,13 @@ void postUpdateToNextCertToExpire(const CertStatusFactory &cert_status_creator,
 }
 
 /**
- * @brief Post an update to the next certificate that needs renewal
+ * @brief Post an update to the next certificates that need renewal
  *
- * This function will post an update to the next certificate that needs renewal.
- * Certificates that need renewal are those that are in the VALID, PENDING_APPROVAL or PENDING state
- * and the not after time is now in the past.
+ * This function will post an update to the next certificates that need renewal.
+ * Certificates that need renewal are those that are in the VALID, PENDING_APPROVAL, or PENDING state,
+ * and the not-after time is now in the past.
  *
- * We can change the status of the certificate to PENDING_RENEWAL and post the status to the shared wildcard PV.
- *
- * We only do one at a time so we can reschedule the rest for the next loop
+ * We can change the status of the certificates to PENDING_RENEWAL and post the status to the shared wildcard PV.
  *
  * @param cert_status_creator The certificate status creator
  * @param status_monitor_params The status monitor parameters
@@ -2450,10 +2527,31 @@ void postUpdateToNextCertToNeedRenewal(const CertStatusFactory &cert_status_crea
 }
 
 /**
+ * @brief Post an update to the next certificate statuses that are becoming invalid
+ *
+ * This function will post an update to the next certificate statuses that are becoming invalid.
+ * Certificate statuses that are becoming invalid are those that are in the VALID, PENDING_APPROVAL, or PENDING state,
+ * we are now more than halfway between the last status update and the status lifetime.
+ *
+ * We update the status date and post it to the shared wildcard PV.
+ *
+ * @param cert_status_creator The certificate status creator
+ * @param status_monitor_params The status monitor parameters
+ */
+void postUpdatesToNextCertStatusToBecomeInvalid(const CertStatusFactory &cert_status_creator,
+                                  const StatusMonitor &status_monitor_params) {
+    while (postUpdatesToNextCertStatusToBecomeInvalid(cert_status_creator,
+                                 status_monitor_params.status_pv_,
+                                 status_monitor_params.certs_db_,
+                                 status_monitor_params.config_.cert_pv_prefix,
+                                 status_monitor_params.issuer_id_));
+}
+
+/**
  * @brief Post an update to the all certificates whose statuses are becoming invalid
  *
  * This function will post an update to the all certificates whose statuses are becoming invalid.
- * Certificates that are becoming invalid are those that are in the VALID, PENDING or PENDING_APPROVAL state
+ * Certificates that are becoming invalid are those that are in the VALID, PENDING, or PENDING_APPROVAL state,
  * and the status validity time is now nearly up.  We use the timeout value (default 5 seconds) to determine
  * "nearly up".
  *
@@ -2512,7 +2610,7 @@ void postUpdatesToExpiredStatuses(const CertStatusFactory &cert_status_creator,
  * @brief The main loop for the certificate monitor.
  *
  * This function will post an update to the next certificate that is becoming valid,
- * the next certificate that is becoming expired
+ * the next certificate that is becoming expired,
  * and any certificates whose statuses are becoming invalid.
  *
  * @param status_monitor_params The status monitor parameters
@@ -2537,6 +2635,9 @@ timeval statusMonitor(const StatusMonitor &status_monitor_params) {
     if (!status_monitor_params.active_status_validity_.empty()) {
         postUpdatesToExpiredStatuses(cert_status_creator, status_monitor_params);
     }
+
+    // Search for all certs whose status is becoming invalid
+    postUpdatesToNextCertStatusToBecomeInvalid(cert_status_creator, status_monitor_params);
 
     log_debug_printf(pvacmsmonitor, "Certificate Monitor Thread Sleep%s", "\n");
     return {};

--- a/certs/pvacms.h
+++ b/certs/pvacms.h
@@ -43,7 +43,8 @@
     "     approved INTEGER,"            \
     "     not_before INTEGER,"          \
     "     not_after INTEGER,"           \
-    "     renew_by INTEGER,"       \
+    "     renew_by INTEGER,"            \
+    "     renewal_due INTEGER,"         \
     "     status INTEGER,"              \
     "     status_date INTEGER"          \
     "); "                               \
@@ -76,7 +77,8 @@
     "     approved,"                  \
     "     not_before,"                \
     "     not_after,"                 \
-    "     renew_by,"             \
+    "     renew_by,"                  \
+    "     renewal_due,"               \
     "     status,"                    \
     "     status_date"                \
     ") "                              \
@@ -90,7 +92,8 @@
     "     :approved,"                 \
     "     :not_before,"               \
     "     :not_after,"                \
-    "     :renew_by,"            \
+    "     :renew_by,"                 \
+    "     0,"                         \
     "     :status,"                   \
     "     :status_date"               \
     ")"
@@ -108,33 +111,11 @@
     "FROM certs "                       \
     "WHERE skid = :skid "
 
-// Delete certs that have become obsolete due to renewal
-#define SQL_DELETE_RENEWER_CERTS      \
-    "DELETE FROM certs "              \
-    "WHERE CN = :CN "                 \
-    "  AND O = :O "                   \
-    "  AND OU = :OU "                 \
-    "  AND C = :C "                   \
-    "  AND status IN (:status0, :status1, :status2, :status3) " \
-    "  AND NOT (serial = :serial OR not_before = (  "      \
-    "      SELECT not_before "       \
-    "        FROM certs "            \
-    "       WHERE CN = :CN "         \
-    "         AND O = :O "           \
-    "         AND OU = :OU "         \
-    "         AND C = :C "           \
-    "         AND status IN (:status0, :status1, :status2, :status3) " \
-    "         AND renew_by != 0 " \
-    "       ORDER BY not_before ASC " \
-    "       LIMIT 1 "                \
-    "      ) "                       \
-    "    )"
-
-// Get the original certificate being renewed
+// Get the certificate due to be renewed
 #define SQL_GET_RENEWED_CERT          \
     "SELECT serial"                   \
     "     , not_after "               \
-    "     , renew_by "           \
+    "     , renew_by "                \
     "     , status "                  \
     "FROM certs "                     \
     "WHERE CN = :CN "                 \
@@ -143,14 +124,21 @@
     "  AND C = :C "                   \
     "  AND status IN (:status0, :status1, :status2, :status3) " \
     "  AND serial != :serial "        \
-    "  AND renew_by != 0 "       \
+    "  AND renewal_due != 0 "         \
     "LIMIT 1 "                        \
 
 #define SQL_RENEW_CERTS               \
     "UPDATE certs "                   \
     "SET status = :status "           \
-    "  , renew_by = :renew_by " \
     "  , status_date = :status_date " \
+    "  , renew_by = :renew_by "       \
+    "  , renewal_due = 0 " \
+    "WHERE serial = :serial "
+
+#define SQL_FLAG_RENEW_CERTS          \
+    "UPDATE certs "                   \
+    "SET status_date = :status_date " \
+    "  , renewal_due = 1 " \
     "WHERE serial = :serial "
 
 #define SQL_CERT_STATUS               \
@@ -162,7 +150,7 @@
 #define SQL_CERT_VALIDITY             \
     "SELECT not_before "              \
     "     , not_after "               \
-    "     , renew_by "           \
+    "     , renew_by "                \
     "FROM certs "                     \
     "WHERE serial = :serial"
 
@@ -170,6 +158,7 @@
     "UPDATE certs "                   \
     "SET status = :status "           \
     "  , status_date = :status_date " \
+    "  , renewal_due = 0 "            \
     "WHERE serial = :serial "
 
 #define SQL_CERT_SET_STATUS_W_APPROVAL \
@@ -177,14 +166,15 @@
     "SET status = :status "            \
     "  , approved = :approved "        \
     "  , status_date = :status_date "  \
+    "  , renewal_due = 0 "            \
     "WHERE serial = :serial "
 
 #define SQL_CERT_TO_VALID              \
     "SELECT serial "                   \
     "FROM certs "                      \
-    "WHERE not_before <= strftime('%s', 'now') " \
-    "  AND not_after > strftime('%s', 'now') "   \
-    "  AND (renew_by = 0 OR renew_by > strftime('%s', 'now')) "
+    "WHERE not_before <= :now "        \
+    "  AND not_after > :now "          \
+    "  AND (renew_by = 0 OR renew_by > :now) "
 
 #define SQL_CERT_BECOMING_INVALID      \
     "SELECT serial, status "           \
@@ -194,21 +184,30 @@
 #define SQL_CERT_TO_EXPIRED            \
     "SELECT serial "                   \
     "FROM certs "                      \
-    "WHERE not_after <= strftime('%s', 'now') "
+    "WHERE not_after <= :now "
 
-#define SQL_CERT_TO_EXPIRED_WITH_FULL_SKID      \
-    "SELECT serial "                            \
-    "FROM certs "                               \
-    "WHERE not_after <= strftime('%s', 'now') " \
+#define SQL_CERT_TO_EXPIRED_WITH_FULL_SKID \
+    "SELECT serial "                       \
+    "FROM certs "                          \
+    "WHERE not_after <= :now "             \
     "  AND skid = :skid "
 
-#define SQL_CERT_TO_PENDING_RENEWAL    \
-    "SELECT serial "                   \
-    "FROM certs "                      \
-    "WHERE not_before <= strftime('%s', 'now') " \
-    "  AND not_after > strftime('%s', 'now') "   \
-    "  AND renew_by != 0 "        \
-    "  AND renew_by <= strftime('%s', 'now') "
+#define SQL_CERT_NEARING_RENEWAL   \
+    "SELECT serial "               \
+    "FROM certs "                  \
+    "WHERE renewal_due = 0 "       \
+    "  AND not_before <= :now "    \
+    "  AND not_after > :now "      \
+    "  AND renew_by != 0 "         \
+    "  AND 2 * :now >= status_date + renew_by "
+
+#define SQL_CERT_TO_PENDING_RENEWAL \
+    "SELECT serial "                \
+    "FROM certs "                   \
+    "WHERE not_before <= :now "     \
+    "  AND not_after > :now "       \
+    "  AND renew_by != 0 "          \
+    "  AND renew_by <= :now "
 
 #define SQL_PRIOR_APPROVAL_STATUS \
     "SELECT approved "            \
@@ -230,7 +229,7 @@ namespace certs {
  * for all certificates that have just expired and all certificates that have just become valid.  If any
  * are found then the associated shared wildcard PV is updated and the new status stored in the database.
  *
- * @param certs_db The certificates database object.
+ * @param certs_db The certificates-database object.
  * @param issuer_id The issuer ID.
  * @param status_pv The shared wildcard PV to notify.
  *

--- a/certs/pvacms.h
+++ b/certs/pvacms.h
@@ -127,6 +127,11 @@
     "  AND renewal_due != 0 "         \
     "LIMIT 1 "                        \
 
+#define SQL_TOUCH_CERT_STATUS         \
+    "UPDATE certs "                   \
+    "SET status_date = :status_date " \
+    "WHERE serial = :serial "
+
 #define SQL_RENEW_CERTS               \
     "UPDATE certs "                   \
     "SET status = :status "           \
@@ -192,6 +197,21 @@
     "WHERE not_after <= :now "             \
     "  AND skid = :skid "
 
+#define SQL_CERT_TO_PENDING_RENEWAL \
+    "SELECT serial "                \
+    "FROM certs "                   \
+    "WHERE not_before <= :now "     \
+    "  AND not_after > :now "       \
+    "  AND renew_by != 0 "          \
+    "  AND renew_by <= :now "
+
+#define SQL_CERT_STATUS_NEARLY_INVALID \
+    "SELECT serial, status "        \
+    "FROM certs "                   \
+    "WHERE not_before <= :now "     \
+    "  AND not_after > :now "       \
+    "  AND 2 * (:now - status_date) >= :status_validity "
+
 #define SQL_CERT_NEARING_RENEWAL   \
     "SELECT serial "               \
     "FROM certs "                  \
@@ -200,14 +220,6 @@
     "  AND not_after > :now "      \
     "  AND renew_by != 0 "         \
     "  AND 2 * :now >= status_date + renew_by "
-
-#define SQL_CERT_TO_PENDING_RENEWAL \
-    "SELECT serial "                \
-    "FROM certs "                   \
-    "WHERE not_before <= :now "     \
-    "  AND not_after > :now "       \
-    "  AND renew_by != 0 "          \
-    "  AND renew_by <= :now "
 
 #define SQL_PRIOR_APPROVAL_STATUS \
     "SELECT approved "            \
@@ -361,6 +373,8 @@ void updateCertificateStatus(const sql_ptr &certs_db, uint64_t serial, certstatu
 
 void updateCertificateRenewalStatus(const sql_ptr &certs_db, serial_number_t serial, certstatus_t cert_status, time_t renew_by);
 
+void touchCertificateStatus(const sql_ptr &certs_db, serial_number_t serial);
+
 certstatus_t storeCertificate(const sql_ptr &certs_db, CertFactory &cert_factory);
 
 timeval statusMonitor(const StatusMonitor &status_monitor_params);
@@ -368,7 +382,7 @@ timeval statusMonitor(const StatusMonitor &status_monitor_params);
 Value postCertificateStatus(server::WildcardPV &status_pv, const std::string &pv_name, uint64_t serial, const PVACertificateStatus &cert_status = {});
 
 std::string getValidStatusesClause(const std::vector<certstatus_t> &valid_status);
-void bindValidStatusClauses(sqlite3_stmt *sql_statement, const std::vector<certstatus_t> &valid_status);
+void bindValidStatusClauses(sqlite3_stmt *sql_statement, const std::vector<certstatus_t> &valid_status = {});
 uint64_t getParameters(const std::list<std::string> &parameters);
 
 template <typename T>

--- a/certs/pvacms.h
+++ b/certs/pvacms.h
@@ -258,7 +258,9 @@ class StatusMonitor {
     ossl_ptr<EVP_PKEY> &cert_auth_pkey_;
     pvxs::ossl_shared_ptr<STACK_OF(X509)> &cert_auth_cert_chain_;
     std::map<serial_number_t, time_t> &active_status_validity_;
-
+  private:
+    mutable epicsMutex lock_;
+  public:
     StatusMonitor(ConfigCms &config, sql_ptr &certs_db, std::string &issuer_id, server::WildcardPV &status_pv, ossl_ptr<X509> &cert_auth_cert,
                   ossl_ptr<EVP_PKEY> &cert_auth_pkey, ossl_shared_ptr<STACK_OF(X509)> &cert_auth_chain,
                   std::map<serial_number_t, time_t> &active_status_validity)
@@ -274,6 +276,7 @@ class StatusMonitor {
     std::vector<serial_number_t> getActiveSerials() const {
         const auto cutoff{time(nullptr) - static_cast<uint64_t>(config_.request_timeout_specified)};
         std::vector<serial_number_t> result;
+        Guard G(lock_);
         for (const auto &pair : active_status_validity_) {
             if (pair.second > cutoff) {
                 result.push_back(pair.first);
@@ -285,11 +288,11 @@ class StatusMonitor {
     /**
      * @brief Set the new validity timeout after we've updated the database
      * Note that its possible that the serial has been removed by another thread during the operation
-     * TODO make threadsafe
      * @param serial the serial number of the validity we need to update
      * @param validity_date the new validity date
      */
     void setValidity(const serial_number_t serial, const time_t validity_date) const {
+        Guard G(lock_);
         const auto it = active_status_validity_.find(serial);
         if (it != active_status_validity_.end()) {
             it->second = validity_date;

--- a/src/certdate.h
+++ b/src/certdate.h
@@ -399,7 +399,7 @@ struct CertDate {
      */
     static std::string formatDurationMins(const int64_t duration) {
     if (duration == 0) return "0m";
-    if (duration < 0) throw CertTimeParseException("Cannot format negative duration");
+    if (duration < 0) throw CertTimeParseException(SB() << "Cannot format negative duration: " << duration);
 
     // Work with seconds for greater precision
     const int64_t seconds = duration * 60;

--- a/src/certfactory.cpp
+++ b/src/certfactory.cpp
@@ -431,14 +431,14 @@ void CertFactory::addCustomExtensionByNid(const ossl_ptr<X509> &certificate, con
         throw std::runtime_error("Adding custom extension: Failed to create ASN1_IA5STRING object");
     }
 
-    // Set the string data using IA5STRING
+    // Set the string data using ASN1_STRING_set
     if (!ASN1_STRING_set(string_data.get(), value.c_str(), value.size())) {
         const auto err = ERR_get_error();
         ERR_error_string_n(err, err_msg, sizeof(err_msg));
         throw std::runtime_error(SB() << "Adding custom extension: Failed to set ASN1_STRING: " << err_msg);
     }
 
-    // Create a new extension using your smart pointer
+    // Create a new extension using the smart pointer
     const ossl_ptr<X509_EXTENSION> ext(X509_EXTENSION_create_by_NID(nullptr, nid, false, string_data.get()), false);
     if (!ext) {
         const auto err = ERR_get_error();

--- a/src/certfactory.cpp
+++ b/src/certfactory.cpp
@@ -120,10 +120,6 @@ ossl_ptr<X509> CertFactory::create() {
         if (!cert_config_uri_base_.empty()) {
             addCustomExtensionByNid(certificate, ossl::NID_SPvaCertConfigURI, getConfigURI(cert_pv_prefix_, issuer_id, skid));
         }
-
-        if (renew_by_ > 0 &&  renew_by_ != not_after_) {
-            addCustomTimeExtensionByNid(certificate, ossl::NID_SPvaRenewByDate, renew_by_);
-        }
     }
 
     // 12. Create cert chain from issuer's chain and issuer's cert

--- a/src/certfilefactory.h
+++ b/src/certfilefactory.h
@@ -36,6 +36,7 @@ struct CertData {
     ossl_ptr<X509> cert;
     ossl_shared_ptr<STACK_OF(X509)> cert_auth_chain;
     std::shared_ptr<KeyPair> key_pair;
+    time_t renew_by{0};
 
     CertData(ossl_ptr<X509>& newCert, ossl_shared_ptr<STACK_OF(X509)>& newCa) : cert(std::move(newCert)), cert_auth_chain(newCa) {}
     CertData(ossl_ptr<X509>& newCert, ossl_shared_ptr<STACK_OF(X509)>& newCa, std::shared_ptr<KeyPair> key_pair)

--- a/src/certstatus.h
+++ b/src/certstatus.h
@@ -395,6 +395,8 @@ struct CertStatus {
                                  enum_value.build().as("status"),
                                  Member(TypeCode::UInt64, "serial"),
                                  Member(TypeCode::String, "state"),
+                                 Member(TypeCode::UInt64, "renew_by"),
+                                 Member(TypeCode::Bool, "renewal_due"),
                                  enum_ocspvalue.build().as("ocsp_status"),
                                  Member(TypeCode::String, "ocsp_state"),
                                  Member(TypeCode::String, "ocsp_status_date"),
@@ -835,10 +837,12 @@ bool operator!=(certstatus_t& lhs, OCSPStatus& rhs);
  */
 struct PVACertificateStatus final : OCSPStatus {
     PVACertStatus status{UNKNOWN};
+    CertDate renew_by{};
     bool operator==(const PVACertificateStatus& rhs) const override {
         return this->status == rhs.status && this->ocsp_status == rhs.ocsp_status && this->status_date == rhs.status_date &&
                this->status_valid_until_date == rhs.status_valid_until_date && this->revocation_date == rhs.revocation_date;
     }
+    bool renewal_due{false};
     bool operator!=(const PVACertificateStatus& rhs) const override { return !(*this == rhs); }
 
     bool operator==(certstatus_t& rhs) const override { return this->status == rhs; }
@@ -890,8 +894,8 @@ struct PVACertificateStatus final : OCSPStatus {
      * @param revocation_time Revocation date
      */
     explicit PVACertificateStatus(const certstatus_t status, const ocspcertstatus_t ocsp_status, const shared_array<const uint8_t>& ocsp_bytes,
-                                  const CertDate& status_date, const CertDate& status_valid_until_time, const CertDate& revocation_time)
-        : OCSPStatus(ocsp_status, ocsp_bytes, status_date, status_valid_until_time, revocation_time), status(status) {}
+                                  const CertDate& status_date, const CertDate& status_valid_until_time, const CertDate& revocation_time, const CertDate& renew_by={}, const bool renewal_due=false)
+        : OCSPStatus(ocsp_status, ocsp_bytes, status_date, status_valid_until_time, revocation_time), status(status), renew_by(renew_by), renewal_due(renewal_due) {}
 
     /**
      * @brief Check if the PVACertificateStatus is self-consistent,

--- a/src/certstatusmanager.h
+++ b/src/certstatusmanager.h
@@ -167,10 +167,8 @@ class CertStatusManager {
     static std::string getConfigPvFromCert(const X509 *cert);
 
     static time_t getExpirationDateFromCert(const ossl_ptr<X509> &cert);
-    static time_t getRenewByFromCert(const ossl_ptr<X509> &cert);
 
     static time_t getExpirationDateFromCert(const X509 *cert);
-    static time_t getRenewByFromCert(const X509 *cert);
 
     /**
      * @brief Used to create a helper that you can use to subscribe to certificate status with
@@ -216,7 +214,6 @@ class CertStatusManager {
      */
     static X509_EXTENSION *getStatusExtension(const X509 *certificate);
     static X509_EXTENSION *getConfigExtension(const X509 *certificate);
-    static X509_EXTENSION *getRenewByDateExtension(const X509 *certificate);
     static ossl_ptr<OCSP_RESPONSE> getOCSPResponse(const shared_array<const uint8_t> &ocsp_bytes);
     static ossl_ptr<OCSP_RESPONSE> getOCSPResponse(const uint8_t *ocsp_bytes, const size_t ocsp_bytes_len);
     static bool verifyOCSPResponse(const ossl_ptr<OCSP_BASICRESP> &basic_response, X509_STORE *trusted_store_ptr);

--- a/src/openssl.cpp
+++ b/src/openssl.cpp
@@ -924,14 +924,6 @@ std::ostream &operator<<(std::ostream &strm, const ShowX509 &cert) {
             (void)BIO_printf(io.get(), "\nValid From     : ");
             (void)BIO_printf(io.get(), the_date.s.c_str());
         }
-        {
-            try {
-                const auto atm = certs::CertStatusManager::getRenewByFromCert(cert.cert);
-                const certs::CertDate the_date(atm);
-                (void)BIO_printf(io.get(), "\nRenew By       : ");
-                (void)BIO_printf(io.get(), the_date.s.c_str());
-            } catch (certs::CertStatusNoExtensionException &e) {}
-        }
         if (const auto atm = X509_get0_notAfter(cert.cert)) {
             const certs::CertDate the_date(atm);
             (void)BIO_printf(io.get(), "\nExpires On     : ");

--- a/src/openssl.cpp
+++ b/src/openssl.cpp
@@ -464,7 +464,7 @@ std::shared_ptr<SSLContext> commonSetup(const SSL_METHOD *method, const bool is_
  * @brief This is the callback that is made by the TLS handshake to add the server OCSP status to the payload
  *
  * @param ssl the SSL session to add the OCSP response to
- * @param server the server object to get the OCSP response from
+ * @param raw the pointer to cast to a Server::Pvt object to get the OCSP response from
  * @return SSL_TLSEXT_ERR_OK if the OCSP response was added successfully,
  *         SSL_TLSEXT_ERR_ALERT_WARNING if the callback should not have been called, (never happens)
  *         SSL_TLSEXT_ERR_NOACK if the OCSP response was not added - no status available to staple at this time
@@ -472,32 +472,40 @@ std::shared_ptr<SSLContext> commonSetup(const SSL_METHOD *method, const bool is_
  */
 int serverOCSPCallback(SSL *ssl, void *raw) {
     auto ret_val = SSL_TLSEXT_ERR_OK;
-    auto server = static_cast<pvxs::server::Server::Pvt *>(raw);
+    const auto server = static_cast<server::Server::Pvt *>(raw);
     log_debug_printf(stapling, "Server OCSP Stapling: %s\n", "serverOCSPCallback");
 
     if (const auto &tls_context = server->tls_context) {
         auto &current_status = tls_context->get_cert_status();
         if (current_status.isValid()) {
+            uint8_t *ocsp_data_ptr_copy = nullptr;
             const auto ocsp_data_ptr = (void *)current_status.ocsp_bytes.data();
             const auto ocsp_data_len = current_status.ocsp_bytes.size();
-            uint8_t *ocsp_data_ptr_copy = nullptr;
 
-            // Allocate a new one and copy in the response data
-            // TODO Verify that this is really freed up by the framework after it is stapled
-            ocsp_data_ptr_copy = static_cast<uint8_t *>(OPENSSL_malloc(ocsp_data_len));
-            memcpy(ocsp_data_ptr_copy, ocsp_data_ptr, ocsp_data_len);
-
-            if (ocsp_data_ptr_copy) {
-                // Staple the data as the OCSP response for the TLS handshake
-                if (SSL_set_tlsext_status_ocsp_resp(ssl, ocsp_data_ptr_copy, ocsp_data_len) != 1) {
-                    log_warn_printf(stapling, "Server OCSP Stapling: %s\n", "unable to staple server status");
+             // OpenSSL API takes an int length. Check for overflow.
+            if (ocsp_data_len > INT_MAX) {
+                log_warn_printf(stapling, "OCSP response too large to staple (%zu)\n", ocsp_data_len);
+                ret_val = SSL_TLSEXT_ERR_NOACK;
+            } else {
+                // Allocate a new one and copy in the response data
+                ocsp_data_ptr_copy = static_cast<uint8_t *>(OPENSSL_malloc(ocsp_data_len));
+                if (!ocsp_data_ptr_copy) {
+                    log_warn_printf(stapling, "Unable to allocate memory for OCSP response%s\n", "");
                     ret_val = SSL_TLSEXT_ERR_NOACK;
                 } else {
-                    log_info_printf(stapling, "Server OCSP Stapling: %s\n", "server status stapled");
+                    memcpy(ocsp_data_ptr_copy, ocsp_data_ptr, ocsp_data_len);
+
+                    // On success, OpenSSL takes ownership and will OPENSSL_free() it later.
+                    if (SSL_set_tlsext_status_ocsp_resp(ssl, ocsp_data_ptr_copy, ocsp_data_len) != 1) {
+                        // On failure, we must free it.
+                        OPENSSL_free(ocsp_data_ptr_copy);
+
+                        log_warn_printf(stapling, "Server OCSP Stapling: %s\n", "unable to staple server status");
+                        ret_val = SSL_TLSEXT_ERR_NOACK;
+                    } else {
+                        log_info_printf(stapling, "Server OCSP Stapling: %s\n", "server status stapled");
+                    }
                 }
-            } else {
-                log_warn_printf(stapling, "Server OCSP Stapling: %s\n", "Unable to allocate memory for OCSP response");
-                ret_val = SSL_TLSEXT_ERR_NOACK;
             }
         } else {
             log_info_printf(stapling, "Server OCSP Stapling: %s\n", "Server status not valid.  Not stapling");

--- a/src/openssl.h
+++ b/src/openssl.h
@@ -175,8 +175,8 @@ struct CertStatusExData {
     const evbase loop;
     // The entity certificate
     ossl_ptr<X509> cert{};
-    // TODO Verify lifetime of this raw pointer
-    // The Trusted Root Certificate Authority
+    // The Trusted Root Certificate Authority.  This is the store pointer
+    // from the SSL_CTX that this CertStatusExData is embedded in, so it will have the same lifetime as this object
     X509_STORE* trusted_store_ptr;
     // Whether status checking is enabled for this context.
     // If not then a permanent status is set and monitoring is not configured

--- a/src/opensslgbl.cpp
+++ b/src/opensslgbl.cpp
@@ -35,7 +35,6 @@ namespace ossl {
 
 int NID_SPvaCertStatusURI = NID_undef;
 int NID_SPvaCertConfigURI = NID_undef;
-int NID_SPvaRenewByDate   = NID_undef;
 
 OSSLGbl* ossl_gbl = nullptr;
 
@@ -89,10 +88,6 @@ static void osslInitImpl() {
     NID_SPvaCertConfigURI = OBJ_create(NID_SPvaCertConfigURIID, SN_SPvaCertConfigURI, LN_SPvaCertConfigURI);
     if(NID_SPvaCertConfigURI == NID_undef) {
         throw std::runtime_error("Failed to create NID for " SN_SPvaCertConfigURI);
-    }
-    NID_SPvaRenewByDate = OBJ_create(NID_SPvaRenewByDateID, SN_SPvaRenewByDate, LN_SPvaRenewByDate);
-    if(NID_SPvaRenewByDate == NID_undef) {
-        throw std::runtime_error("Failed to create NID for " SN_SPvaRenewByDate);
     }
 
     ossl_ptr<OSSL_LIB_CTX> ctx(__FILE__, __LINE__, OSSL_LIB_CTX_new());

--- a/src/opensslgbl.h
+++ b/src/opensslgbl.h
@@ -37,7 +37,7 @@ extern void sslkeylogfile_exit(void *) noexcept;
 
 // "1.3.6.1.4.1" OID prefix for custom OIDs
 
-// EPICS OID for "SPvaCertConfigURI" extension: "37427" DTMF for "EPICS" :)
+// EPICS OID for "SPvaCertStatusURI" extension: "37427" DTMF for "EPICS" :)
 #define NID_SPvaCertStatusURIID "1.3.6.1.4.1.37427.1"
 #define SN_SPvaCertStatusURI "ASN.1 - SPvaCertStatusURI"
 #define LN_SPvaCertStatusURI "EPICS SPVA Certificate Status URI"
@@ -47,16 +47,10 @@ extern void sslkeylogfile_exit(void *) noexcept;
 #define SN_SPvaCertConfigURI "ASN.1 - SPvaCertConfigURI"
 #define LN_SPvaCertConfigURI "EPICS SPVA Certificate Config URI"
 
-// EPICS OID for "SPvaRenewByDate" extension: "73639" DTMF for "RENEW" :)
-#define NID_SPvaRenewByDateID "1.3.6.1.4.1.73639.1"
-#define SN_SPvaRenewByDate "ASN.1 - SPvaRenewByDate"
-#define LN_SPvaRenewByDate "EPICS SPVA Renew By Date"
-
 PVXS_API extern void osslInit();
 
 PVXS_API extern int NID_SPvaCertStatusURI;
 PVXS_API extern int NID_SPvaCertConfigURI;
-PVXS_API extern int NID_SPvaRenewByDate;
 
 }  // namespace ossl
 }  // namespace pvxs

--- a/src/pvxs/client.h
+++ b/src/pvxs/client.h
@@ -1086,7 +1086,7 @@ public:
     //! Default configuration using process environment
     static inline Config fromEnv() { return Config{}.applyEnv(); }
     //! update using defined EPICS_PVA* environment variables
-    virtual Config &applyEnv(); // TODO sort out virtual problem
+    virtual Config &applyEnv();
 
     typedef std::map<std::string, std::string> defs_t;
     //! update with definitions as with EPICS_PVA* environment variables

--- a/src/pvxs/config.h
+++ b/src/pvxs/config.h
@@ -133,34 +133,6 @@ struct PVXS_API ConfigCommon {
      */
     bool isTlsConfigured() const { return !tls_disabled && !tls_keychain_file.empty(); }
 #endif  // PVXS_ENABLE_OPENSSL
-
-    struct PickOne {
-        const std::map<std::string, std::string> &defs;
-        bool useenv;
-
-        std::string name, val;
-
-        bool operator()(std::initializer_list<const char *> names) {
-            for (auto candidate : names) {
-                if (useenv) {
-                    if (auto eval = getenv(candidate)) {
-                        name = candidate;
-                        val = eval;
-                        return true;
-                    }
-
-                } else {
-                    auto it = defs.find(candidate);
-                    if (it != defs.end()) {
-                        name = candidate;
-                        val = it->second;
-                        return true;
-                    }
-                }
-            }
-            return false;
-        }
-    };
 };
 }  // namespace impl
 }  // namespace pvxs

--- a/src/pvxs/server.h
+++ b/src/pvxs/server.h
@@ -179,29 +179,29 @@ struct PVXS_API Config : public impl::ConfigCommon {
     //! Supplemented only if auto_beacon==true
     std::vector<std::string> beaconDestinations;
     //! Whether to populate the beacon address list automatically.  (recommended)
-    bool auto_beacon = true;
+    bool auto_beacon;
 
 #ifdef PVXS_ENABLE_OPENSSL
     /**
      * @brief true if server should stop if no cert is available or can be
      * verified if status check is enabled
      */
-    bool tls_stop_if_no_cert = false;
+    bool tls_stop_if_no_cert;
 
     /**
      * @brief true if server should throw an exception if no cert is available or can be
      * verified if status check is enabled
      */
-    bool tls_throw_if_no_cert = false;
+    bool tls_throw_if_no_cert;
 
 #endif // PVXS_ENABLE_OPENSSL
 
     //! Server unique ID.  Only meaningful in readback via Server::config()
-    ServerGUID guid{};
+    ServerGUID guid;
 
 private:
-    bool BE = EPICS_BYTE_ORDER==EPICS_ENDIAN_BIG;
-    bool UDP = true;
+    bool BE;
+    bool UDP;
 public:
 
     // compat
@@ -253,6 +253,17 @@ public:
     inline bool shareUDP() const { return UDP; }
 #endif
     void fromDefs(Config& self, const std::map<std::string, std::string>& defs, bool useenv);
+
+    Config()
+        : auto_beacon(true)
+#ifdef PVXS_ENABLE_OPENSSL
+        , tls_stop_if_no_cert(false)
+        , tls_throw_if_no_cert(false)
+#endif
+        , guid()
+        , BE(EPICS_BYTE_ORDER==EPICS_ENDIAN_BIG)
+        , UDP(true)
+    {}
 };
 
 PVXS_API

--- a/src/utilpvt.h
+++ b/src/utilpvt.h
@@ -346,6 +346,34 @@ struct InstCounter {
 #define DEFINE_INST_COUNTER2(KLASS, NAME) std::atomic<size_t> KLASS::cnt_ ## NAME {0u}
 #define DEFINE_INST_COUNTER(KLASS) DEFINE_INST_COUNTER2(KLASS, KLASS)
 
+struct PickOne {
+    const std::map<std::string, std::string> &defs;
+    bool useenv;
+
+    std::string name, val;
+
+    bool operator()(std::initializer_list<const char *> names) {
+        for (auto candidate : names) {
+            if (useenv) {
+                if (auto eval = getenv(candidate)) {
+                    name = candidate;
+                    val = eval;
+                    return true;
+                }
+
+            } else {
+                auto it = defs.find(candidate);
+                if (it != defs.end()) {
+                    name = candidate;
+                    val = it->second;
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+};
+
 } // namespace pvxs
 
 #endif // UTILPVT_H

--- a/src/wildcardpv.cpp
+++ b/src/wildcardpv.cpp
@@ -336,12 +336,8 @@ void WildcardPV::open(const std::string& pv_name, const Value& initial) {
         // make a second copy as 'temp' will be queued
         temp = initial.clone();
 
-        // TODO these loops will be really inefficient if we aren't on a worker.
-        //      API to batch?
-
         for (auto& op : mpending) {
             Impl::connectSub(G, impl, op, temp);
-            // initial open post()'d
         }
     }
 

--- a/src/wildcardpv.h
+++ b/src/wildcardpv.h
@@ -146,10 +146,8 @@ struct PVXS_API WildcardSource final : Source, std::enable_shared_from_this<Wild
   private:
     mutable RWLock lock;
     pv_list_t pvs;
-    decltype(List::names) list_names;
 
     bool wildcardMatch(const std::string& searched_name, WildcardPV& pv);
-    bool simpleMatch(const std::string& searched_name, WildcardPV& pv);
 
     static const std::string kEpicsWildcardChars;
 };


### PR DESCRIPTION
```
### Description

This pull request addresses several areas in the codebase to improve stability, clarity, performance, and modularity. The key changes include:

- **Thread Safety Enhancements**: Introduced mutex locks for ensuring thread-safe operations in `StatusMonitor` methods like `setValidity` and `getActiveSerials`.
- **Certificate Management**: Refactored certificate renewal logic, added new parameters (`renew_by`, `renewal_due`), optimized conditionals, improved logging, and revamped handling of certificate expiration and renewal processes.
- **OCSP Handling**: Improved memory allocation, error handling, OpenSSL compliance, and removed outdated comments.
- **Code Cleanup**: Removed unused methods and properties, centralized and reorganized structure definitions for improved readability and modularity.
- **Comment Clarity**: Updated multiple comments across the codebase on topics like certificate lifetimes and extension creation for better understanding.

### Checklist

- [ ] Tests for the changes have been added (where applicable)
- [ ] Documentation has been updated to reflect the changes
- [ ] Code has been reviewed and approved by at least one reviewer
- [ ] Any new SQL definitions have been verified and confirmed
- [ ] All checks pass on CI

### Impact

These changes improve code maintainability, security, and performance, particularly in multi-threaded contexts and certificate management tasks.

```