### PR TITLE
Comment out UDP random port check as a temporary workaround

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -829,7 +829,8 @@ void Config::updateDefs(defs_t& defs) const {
 }
 
 void Config::expand() {
-    if (udp_port == 0) throw std::runtime_error("Client can't use UDP random port");
+    // TODO Fix properly.  This HACK to remedy 9e9662f4970e513b61db9c547fa372dc44deb75f
+    // if (udp_port == 0) throw std::runtime_error("Client can't use UDP random port");
 
     if (tcp_port == 0) tcp_port = 5075;
 


### PR DESCRIPTION
This PR temporarily comments out the UDP random port check to address a regression caused by commit 9e9662f4970e513b61db9c547fa372dc44deb75f. A proper fix is required to resolve the issue permanently.